### PR TITLE
BUILDnceplibs fix for contianers

### DIFF
--- a/Build/BUILDnceplibs
+++ b/Build/BUILDnceplibs
@@ -63,39 +63,41 @@ fi
 nceplibs_dir=${NCEP_DIR}/nceplibs/${compiler}
 \rm -rf $nceplibs_dir
 
+#Define common cmake flags
+cmake_flags="-DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_C_STANDARD=99"
 
 git clone https://github.com/NOAA-EMC/NCEPLIBS-bacio
 pushd NCEPLIBS-bacio
-cmake -DCMAKE_C_STANDARD=99 -DCMAKE_INSTALL_PREFIX=${BUILD_ROOT}/Build/NCEPLIBS-bacio/install .
+cmake ${cmake_flags} -DCMAKE_INSTALL_PREFIX=${BUILD_ROOT}/Build/NCEPLIBS-bacio/install .
 make -j8
 make install
 popd
 
 git clone https://github.com/NOAA-EMC/NCEPLIBS-sp
 pushd NCEPLIBS-sp
-cmake -DCMAKE_C_STANDARD=99 -DCMAKE_INSTALL_PREFIX=${BUILD_ROOT}/Build/NCEPLIBS-sp/install .
+cmake ${cmake_flags} -DCMAKE_INSTALL_PREFIX=${BUILD_ROOT}/Build/NCEPLIBS-sp/install .
 make -j8 sp_d
 make install
 popd
 
 git clone https://github.com/NOAA-EMC/NCEPLIBS-w3emc
 pushd NCEPLIBS-w3emc
-cmake -DCMAKE_C_STANDARD=99 -DCMAKE_INSTALL_PREFIX=${BUILD_ROOT}/Build/NCEPLIBS-w3emc/install -DCMAKE_PREFIX_PATH=${BUILD_ROOT}/Build/NCEPLIBS-bacio/install/lib/cmake/bacio/ .
+cmake ${cmake_flags} -DCMAKE_INSTALL_PREFIX=${BUILD_ROOT}/Build/NCEPLIBS-w3emc/install -DCMAKE_PREFIX_PATH=${BUILD_ROOT}/Build/NCEPLIBS-bacio/install/lib/cmake/bacio/ .
 make -j8 w3emc_d
 make install
 popd
 
 git clone https://github.com/NOAA-EMC/NCEPLIBS-w3nco
 pushd NCEPLIBS-w3nco
-cmake -DCMAKE_C_STANDARD=99 -DCMAKE_INSTALL_PREFIX=${BUILD_ROOT}/Build/NCEPLIBS-w3nco/install .
+cmake ${cmake_flags} -DCMAKE_INSTALL_PREFIX=${BUILD_ROOT}/Build/NCEPLIBS-w3nco/install .
 make -j8 w3nco_d
 make install
 popd
 
 mkdir -p $nceplibs_dir
 mv ${BUILD_ROOT}/Build/NCEPLIBS-bacio/install/lib/libbacio.a $nceplibs_dir/.
-mv ${BUILD_ROOT}/Build/NCEPLIBS-sp/install/lib64/libsp_d.a $nceplibs_dir/.
-mv ${BUILD_ROOT}/Build/NCEPLIBS-w3emc/install/lib64/libw3emc_d.a $nceplibs_dir/.
+mv ${BUILD_ROOT}/Build/NCEPLIBS-sp/install/lib/libsp_d.a $nceplibs_dir/.
+mv ${BUILD_ROOT}/Build/NCEPLIBS-w3emc/install/lib/libw3emc_d.a $nceplibs_dir/.
 mv ${BUILD_ROOT}/Build/NCEPLIBS-w3nco/install/lib/libw3nco_d.a $nceplibs_dir/.
 
 \rm -rf NCEPLIBS-bacio NCEPLIBS-sp NCEPLIBS-w3emc NCEPLIBS-w3nco


### PR DESCRIPTION
**Description**

Cmake installs the ncep libraries in different locations depending on the environment that BUILDnceplibs was execute in. I found that when I install inside of a container on Gaea ```libsp_d.a``` and ```libw3emc_d``` were installed in ```<installdir>/lib64``` whereas on my Parallelworks container they were installed in ```<installdir>/lib```.  To make this standard across platforms I added the cmake flag ```-DCMAKE_INSTALL_LIBDIR=lib```.

Fixes # (issue)

**How Has This Been Tested?**

Tested on Gaea and Parallelworks

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
