### PR TITLE
nvhpc-with-openmp

### DIFF
--- a/site/environment.nvhpc.sh
+++ b/site/environment.nvhpc.sh
@@ -30,7 +30,7 @@ case $hostname in
       echo " lsc environment "
 
       source $MODULESHOME/init/sh
-      module load nvhpc/23.1
+      module load nvhpc-with-openmpi/23.1
       module load netcdf/4.9.0
       module load hdf5/1.12.0
       module load cmake/3.18.2


### PR DESCRIPTION
**Description**
Small environment update for nvhpc for the amd dev box.
Changes `nvhpc/23.1` to  `nvhpc-with-openmpi` 

Fixes # (issue)

**How Has This Been Tested?**

Ran C128r3.solo.TC CI test with this compiler on amd box

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
