### PR TITLE
Bug Fixes

### DIFF
--- a/Build/COMPILE
+++ b/Build/COMPILE
@@ -156,6 +156,7 @@ echo -e "\tbit      = $bit"
 echo -e "\tavx      = $avx"
 echo -e "\tcompiler = $compiler"
 echo -e "\tclean    = $clean"
+echo -e "\tyaml     = $yaml"
 echo -e "\n"
 sleep 5
 

--- a/Build/mk_scripts/MAKE_libFMS
+++ b/Build/mk_scripts/MAKE_libFMS
@@ -56,7 +56,7 @@ done
 
 #
 # CPPDEFS needed to build libFMS
-cppDefs="-Duse_libMPI -Duse_netCDF -Duse_LARGEFILE -DHAVE_SCHED_GETAFFINITY -DINTERNAL_FILE_NML -DGFS_PHYS -DGFS_CONSTANTS ${USE_YAML} -DHAVE_GETTID"
+cppDefs="-Duse_libMPI -Duse_netCDF -Duse_LARGEFILE -DHAVE_SCHED_GETAFFINITY -DINTERNAL_FILE_NML -DGFS_PHYS -DGFS_CONSTANTS ${USE_YAML} ${FMS_CPPDEFS}"
 
 #
 # clean up and create the FMS library directory

--- a/Build/mk_scripts/MAKE_libFMS
+++ b/Build/mk_scripts/MAKE_libFMS
@@ -42,7 +42,7 @@ do
         ;;
         noyaml|yaml)
         YAML="${arg#*=}"
-	if [ $YAML='yaml' ] ; then
+	if [ ${YAML} = 'yaml' ] ; then
           USE_YAML=-Duse_yaml
         fi
 	shift # Remove yaml from processing

--- a/site/environment.gnu.sh
+++ b/site/environment.gnu.sh
@@ -43,6 +43,9 @@ case $hostname in
        module load python/3.9
        module load libyaml/0.2.5
 
+       # Add -DHAVE_GETTID to the FMS cppDefs
+       export FMS_CPPDEFS=-DHAVE_GETTID
+
        # make your compiler selections here
        export FC=ftn
        export CC=cc
@@ -75,6 +78,9 @@ case $hostname in
        module load python/3.9
        module load libyaml/0.2.5
 
+       # Add -DHAVE_GETTID to the FMS cppDefs
+       export FMS_CPPDEFS=-DHAVE_GETTID
+
        # make your compiler selections here
        export FC=ftn
        export CC=cc
@@ -103,6 +109,7 @@ case $hostname in
        export HDF5=${HDF5_ROOT}
        export LIBRARY_PATH="${LIBRARY_PATH}:${NETCDF}/lib:${HDF5}/lib"
        export NETCDF_DIR=${NETCDF}
+       export FMS_CPPDEFS=""
 
        # make your compiler selections here
        export FC=mpif90
@@ -131,6 +138,7 @@ case $hostname in
 
        export LIBRARY_PATH="${LIBRARY_PATH}:${NETCDF4}/lib:${HDF5}/lib"
        export NETCDF_DIR=${NETCDF4}
+       export FMS_CPPDEFS=""
 
        # make your compiler selections here
        export FC=mpif90
@@ -158,6 +166,7 @@ case $hostname in
 
        export LIBRARY_PATH="${LIBRARY_PATH}:${NETCDF}/lib:${HDF5}/lib"
        export NETCDF_DIR=${NETCDF}
+       export FMS_CPPDEFS=""
 
        # make your compiler selections here
        export FC=mpif90
@@ -185,6 +194,7 @@ case $hostname in
 
        export CPATH="${NETCDF_ROOT}/include:${CPATH}"
        export NETCDF_DIR=${NETCDF_ROOT}
+       export FMS_CPPDEFS=""
 
        # make your compiler selections here
        export FC=mpif90

--- a/site/environment.gnu.sh
+++ b/site/environment.gnu.sh
@@ -40,7 +40,6 @@ case $hostname in
        module load cray-netcdf/4.9.0.3
        module load craype-hugepages4M
        module load cmake/3.23.1
-       module load python/3.9
        module load libyaml/0.2.5
 
        # Add -DHAVE_GETTID to the FMS cppDefs
@@ -75,7 +74,6 @@ case $hostname in
        module load cray-netcdf/4.8.1.3
        module load craype-hugepages4M
        module load cmake/3.20.1
-       module load python/3.9
        module load libyaml/0.2.5
 
        # Add -DHAVE_GETTID to the FMS cppDefs

--- a/site/environment.intel.sh
+++ b/site/environment.intel.sh
@@ -46,6 +46,9 @@ case $hostname in
       module load python/3.9
       module load libyaml/0.2.5
 
+      # Add -DHAVE_GETTID to the FMS cppDefs
+      export FMS_CPPDEFS=-DHAVE_GETTID
+
       # make your compiler selections here
       export FC=ftn
       export CC=cc
@@ -77,6 +80,9 @@ case $hostname in
       module load python/3.9
       module load libyaml/0.2.5
 
+      # Add -DHAVE_GETTID to the FMS cppDefs
+      export FMS_CPPDEFS=-DHAVE_GETTID
+
       # make your compiler selections here
       export FC=ftn
       export CC=cc
@@ -104,6 +110,7 @@ case $hostname in
       export HDF5=${HDF5_ROOT}
       export LIBRARY_PATH="${LIBRARY_PATH}:${NETCDF}/lib:${HDF5}/lib"
       export NETCDF_DIR=${NETCDF}
+      export FMS_CPPDEFS=""
 
       # make your compiler selections here
       export FC=mpiifort
@@ -133,6 +140,7 @@ case $hostname in
 
       export LIBRARY_PATH="${LIBRARY_PATH}:${NETCDF4}/lib:${HDF5}/lib"
       export NETCDF_DIR=${NETCDF4}
+      export FMS_CPPDEFS=""
 
       # make your compiler selections here
       export FC=mpiifort
@@ -155,6 +163,7 @@ case $hostname in
 
       export LIBRARY_PATH="${LIBRARY_PATH}:${NETCDF}/lib:${HDF5}/lib"
       export NETCDF_DIR=${NETCDF}
+      export FMS_CPPDEFS=""
 
       # make your compiler selections here
       export FC=mpiifort
@@ -182,6 +191,7 @@ case $hostname in
 
       export CPATH="${NETCDF_ROOT}/include:${CPATH}"
       export NETCDF_DIR=${NETCDF_ROOT}
+      export FMS_CPPDEFS=""
 
       # make your compiler selections here
       export FC=mpiifort

--- a/site/environment.intel.sh
+++ b/site/environment.intel.sh
@@ -43,7 +43,6 @@ case $hostname in
       module load cray-netcdf
       module load craype-hugepages4M
       module load cmake/3.23.1
-      module load python/3.9
       module load libyaml/0.2.5
 
       # Add -DHAVE_GETTID to the FMS cppDefs
@@ -77,7 +76,6 @@ case $hostname in
       module load cray-netcdf/4.8.1.3
       module load craype-hugepages4M
       module load cmake/3.20.1
-      module load python/3.9
       module load libyaml/0.2.5
 
       # Add -DHAVE_GETTID to the FMS cppDefs

--- a/site/gnu.mk
+++ b/site/gnu.mk
@@ -39,7 +39,7 @@ else
   INCLUDE = -I$(NETCDF_ROOT)/include
   LIBS += -lnetcdff -lnetcdf -lhdf5_hl -lhdf5 -lz
 endif
-INCLUDE := $(shell pkg-config --cflags yaml-0.1)
+INCLUDE += $(shell pkg-config --cflags yaml-0.1)
 FPPFLAGS := -cpp -Wp,-w $(INCLUDE)
 CPPFLAGS := $(shell pkg-config --cflags yaml-0.1)
 
@@ -120,7 +120,7 @@ ifeq ($(NETCDF),3)
     CPPDEFS += -Duse_LARGEFILE
   endif
 endif
-LIBS := $(shell pkg-config --libs yaml-0.1)
+LIBS += $(shell pkg-config --libs yaml-0.1)
 LDFLAGS += $(LIBS) -L$(NETCDF_ROOT)/lib -L$(HDF5_DIR)/lib
 
 #---------------------------------------------------------------------------

--- a/site/intel.mk
+++ b/site/intel.mk
@@ -123,7 +123,7 @@ ifeq ($(NETCDF),3)
   endif
 endif
 
-LIBS := $(shell pkg-config --libs yaml-0.1)
+LIBS += $(shell pkg-config --libs yaml-0.1)
 LDFLAGS += $(LIBS)
 
 #---------------------------------------------------------------------------

--- a/site/intel.mk
+++ b/site/intel.mk
@@ -39,7 +39,7 @@ else
   INCLUDE = -I$(NETCDF_ROOT)/include
   LIBS += -lnetcdff -lnetcdf -lhdf5_hl -lhdf5 -lz
 endif
-INCLUDE := $(shell pkg-config --cflags yaml-0.1)
+INCLUDE += $(shell pkg-config --cflags yaml-0.1)
 FPPFLAGS := -fpp -Wp,-w $(INCLUDE)
 CPPFLAGS := $(shell pkg-config --cflags yaml-0.1)
 


### PR DESCRIPTION
**Description**

In PR #22 I accidentally introduced a few bugs.  This PR should address those.

1. the -DHAVE_GETTID flag should only be added to FMS compiles for GAEA, so we moved it to the entvironment files.
2. A copy/paste error when I added some new lines in intel.mk and gnu.mk related to libyaml.  I correct that here
3. My if statement in MAKE_libFMS that woud set the variable USE_YAML was not working as expected and is fixed.

Fixes # (issue)

**How Has This Been Tested?**

Tested on Gaea, Orion, and the cloud

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
