### PR TITLE
Update to FMS 2023.02

### DIFF
--- a/CHECKOUT_code
+++ b/CHECKOUT_code
@@ -35,8 +35,8 @@ release="main"
 
 fv3_release=$release
 phy_release=$release
-fms_release="2023.01"
-drivers_release="2023.01"
+fms_release="2023.02"
+drivers_release="2023.02"
 
 git clone -b ${fv3_release}   https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
 git clone -b ${phy_release}   https://github.com/NOAA-GFDL/SHiELD_physics

--- a/RTS/CI/C128r3.solo.TC
+++ b/RTS/CI/C128r3.solo.TC
@@ -367,7 +367,7 @@ cat > input.nml <<EOF
 
  &integ_phys_nml
        do_inline_mp = .T.
-       do_sat_adj = .T.
+       do_sat_adj = .F.
 /
 
 &fv_diag_plevs_nml


### PR DESCRIPTION
**Description**

This PR will update to use FMS2023.02 in the checkout script.  This also corrects an error previously made in a test script:
https://github.com/NOAA-GFDL/SHiELD_build/commit/d1925369e8f431dc28d614e2fb7e122c84db1604#diff-8bec0eb14d995ea7efe9bd4a70ae239f64f433ab2a89bfadb06a346f5cce40c0L337

Fixes # (issue)

**How Has This Been Tested?**
Tested on Gaea

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
