### PR TITLE
Make modifications needed to build a Python-wrapped version of SHiELD

### DIFF
--- a/Build/BUILDlibfms
+++ b/Build/BUILDlibfms
@@ -41,6 +41,10 @@
              yaml="${arg#*=}"
              shift # Remove "yaml" from processing
              ;;
+          nopic|pic)
+             pic="${arg#*=}"
+             shift # Remove "PIC" from processing
+             ;;
           *)
           if [ ${arg#} != '--help' ] && [ ${arg#} != '-h' ] ; then
             echo "option "${arg#}" not found"
@@ -49,6 +53,7 @@
           echo -e "valid options are:"
           echo -e "\t[intel(D) | gnu | nvhpc] \t\t\t compiler"
 	  echo -e "\t[noyaml(D) | yaml] \t\t\t whether to build with -Duse_yaml"
+          echo -e "\t[nopic(D) | pic] \t\t\t whether to build all components with the -fPIC flag (position independent code)"
           echo -e "\n"
           exit
           ;;
@@ -74,7 +79,7 @@ fi
 #
 # build FMS library
 echo " building ${NCEP_DIR}/libFMS/${compiler}"
-MAKE_libFMS ${compiler} ${yaml} >> build_libFMS_${compiler}.out 2>&1   # build 32bit and 64bit versions of libFMS
+MAKE_libFMS ${compiler} ${yaml} ${pic} >> build_libFMS_${compiler}.out 2>&1   # build 32bit and 64bit versions of libFMS
 #
 # test and report on libFMS build success
 if [ $? -ne 0 ] ; then

--- a/Build/BUILDlibfms
+++ b/Build/BUILDlibfms
@@ -28,6 +28,7 @@
 # configure your build parameters
   compiler="intel"
   yaml="noyaml"
+  pic="nopic"
 #
 # parse arguments
   for arg in "$@"

--- a/Build/BUILDnceplibs
+++ b/Build/BUILDnceplibs
@@ -40,6 +40,10 @@ version_w3nco="v2.4.1"
              compiler="${arg#*=}"
              shift # Remove "compiler" from processing
              ;;
+          nopic|pic)
+             pic="${arg#*=}"
+             shift # Remove "pic" from processing
+             ;;
           *)
           if [ ${arg#} != '--help' ] && [ ${arg#} != '-h' ] ; then
             echo "option "${arg#}" not found"
@@ -47,6 +51,7 @@ version_w3nco="v2.4.1"
           echo -e ' '
           echo -e "valid options are:"
           echo -e "\t[intel(D) | gnu | nvhpc] \t\t\t compiler"
+          echo -e "\t[nopic(D) | pic] \t\t\t whether to build all components with the -fPIC flag (position independent code)"
           echo -e "\n"
           exit
           ;;
@@ -72,7 +77,11 @@ mkdir -p $nceplibs_dir
 cd $nceplibs_dir
 
 #Define common cmake flags
-cmake_flags="-DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_C_STANDARD=99"
+if [ ${pic} = 'pic' ] ; then
+  cmake_flags="-DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_C_STANDARD=99 -DCMAKE_POSITION_INDEPENDENT_CODE=ON"
+else
+  cmake_flags="-DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_C_STANDARD=99"
+fi
 
 git clone -b $version_bacio https://github.com/NOAA-EMC/NCEPLIBS-bacio
 pushd NCEPLIBS-bacio

--- a/Build/BUILDnceplibs
+++ b/Build/BUILDnceplibs
@@ -23,8 +23,9 @@
 #  DISCLAIMER: This script is provided as-is and as such is unsupported.
 #
 
-#set default compiler
+# set default values
 compiler="intel"
+pic="nopic"
 
 #define versions to checkout
 version_bacio="v2.6.0"

--- a/Build/COMPILE
+++ b/Build/COMPILE
@@ -109,6 +109,10 @@ spin()
              yaml="${arg#*=}"
 	     shift # Remove "yaml" from processing
 	     ;;
+          nopic|pic)
+             pic="${arg#*=}"
+             shift # Remove "pic" from processing
+             ;;
           *)
           if [ ${arg#} != '--help' ] && [ ${arg#} != '-h' ] ; then
             echo "option "${arg#}" not found"
@@ -123,6 +127,7 @@ spin()
           echo -e "\t[intel(D) | gnu | nvhpc] \t\t\t compiler"
           echo -e "\t[noclean(D) | clean | cleanall] \t cleans exec area"
 	  echo -e "\t[noyaml(D) | yaml] \t will build the FMS library with the -Duse_yaml library.  Default is no yaml"
+          echo -e "\t[nopic(D) | pic] \t whether to build all components with the -fPIC flag (position independent code)"
           echo -e "\n"
           exit
           ;;
@@ -157,6 +162,7 @@ echo -e "\tavx      = $avx"
 echo -e "\tcompiler = $compiler"
 echo -e "\tclean    = $clean"
 echo -e "\tyaml     = $yaml"
+echo -e "\tpic      = $pic"
 echo -e "\n"
 sleep 5
 
@@ -205,7 +211,7 @@ fi
      echo " pre-built ${NCEP_DIR}/libFMS/${compiler} exists"
   else
      echo " ${NCEP_DIR}/libFMS/${compiler} does not exist"
-     ./BUILDlibfms ${compiler} ${yaml}
+     ./BUILDlibfms ${compiler} ${yaml} ${pic}
      if [ $? -ne 0 ] ; then
         echo ">>> ${NCEP_DIR}/Libfms/${compiler} build failed"
         exit 2
@@ -218,7 +224,7 @@ fi
      echo " pre-built ${NCEP_DIR}/nceplibs/${compiler} exists"
   else
      echo " ${NCEP_DIR}/nceplibs/${compiler} does not exist"
-     ./BUILDnceplibs ${compiler}
+     ./BUILDnceplibs ${compiler} ${pic}
      if [ $? -ne 0 ] ; then
         echo ">>> ${NCEP_DIR}/ncepdir/${compiler} build failed"
         exit 3
@@ -248,7 +254,7 @@ echo -e "  building ${config} ${hydro} ${comp} ${bit} ${compiler} \t `date`"
     fi
   #
   # build the configuration
-    mk_make ${config} ${hydro} ${comp} ${bit} ${avx} ${compiler} >> build_${config}_${hydro}.${comp}.${bit}.${compiler}.out 2>&1
+    mk_make ${config} ${hydro} ${comp} ${bit} ${avx} ${compiler} ${pic} >> build_${config}_${hydro}.${comp}.${bit}.${compiler}.out 2>&1
   #
   # move the executable to an accessible area
     mv exec/${config}_${hydro}.${comp}.${bit}.${compiler}/test.x bin/${config_name}_${hydro}.${comp}.${bit}.${compiler}.x

--- a/Build/COMPILE
+++ b/Build/COMPILE
@@ -56,6 +56,7 @@ spin()
   compiler="intel"
   clean="noclean"
   yaml="noyaml"
+  pic="nopic"
 
   config_name="SHiELD"
 

--- a/Build/mk_scripts/MAKE_libFMS
+++ b/Build/mk_scripts/MAKE_libFMS
@@ -47,6 +47,15 @@ do
         fi
 	shift # Remove yaml from processing
 	;;
+        nopic|pic)
+        pic="${arg#*=}"
+        if [ ${pic} = 'pic' ] ; then
+          PIC="Y"
+        else
+          PIC="N"
+        fi
+        shift # Remove "PIC" from processing
+        ;;
     esac
 done
 
@@ -72,7 +81,7 @@ pushd ${NCEP_DIR}/libFMS/${COMPILER}/${bit}
 mkmf -m Makefile -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "$cppDefs" \
      -p libFMS.a ${NCEP_DIR}/libFMS/${COMPILER}/${bit}/pathnames_fms
 echo "building ${NCEP_DIR}/libFMS/${COMPILER}/32bit/libFMS.a..."
-make -j8 OPENMP=Y AVX=Y 32BIT=Y Makefile libFMS.a >& Build_libFMS.out
+make -j8 OPENMP=Y AVX=Y 32BIT=Y PIC=${PIC} Makefile libFMS.a >& Build_libFMS.out
 
 #
 # test and report on build success
@@ -95,7 +104,7 @@ pushd ${NCEP_DIR}/libFMS/${COMPILER}/${bit}
 mkmf -m Makefile -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "$cppDefs" \
      -p libFMS.a ${NCEP_DIR}/libFMS/${COMPILER}/${bit}/pathnames_fms
 echo "building ${NCEP_DIR}/libFMS/${COMPILER}/64bit/libFMS.a..."
-make -j8 OPENMP=Y AVX=Y Makefile libFMS.a >& Build_libFMS.out
+make -j8 OPENMP=Y AVX=Y PIC=${PIC} Makefile libFMS.a >& Build_libFMS.out
 
 #
 # test and report on build success

--- a/Build/mk_scripts/MAKE_libFMS
+++ b/Build/mk_scripts/MAKE_libFMS
@@ -30,6 +30,7 @@ SHiELD_SRC=${PWD%/*/*}/SHiELD_SRC
 PATH="${BUILD_ROOT}/mkmf/bin:${PATH}"
 COMPILER="intel"
 YAML="noyaml"
+pic="nopic"
 
 #
 ## parse arguments

--- a/Build/mk_scripts/mk_make
+++ b/Build/mk_scripts/mk_make
@@ -72,6 +72,14 @@ do
           COMPILER="${arg#*=}"
           shift # Remove COMPILER from processing
           ;;
+        nopic|pic)
+          if [ "${arg#*=}" = 'pic' ] ; then
+            PIC=Y
+          else
+            PIC=N
+          fi
+          shift # Remove PIC from processing
+          ;;
     esac
 done
 
@@ -81,15 +89,22 @@ module list
 
 $FC --version
 
-NCEPLIBS="${NCEP_DIR}/libFMS/${COMPILER}/${bit}/libFMS.a"
 if [ ${CONFIG} = 'shield' ] ; then
+  NCEPLIBS="./libfv3.a"
+  NCEPLIBS+=" ${NCEP_DIR}/libFMS/${COMPILER}/${bit}/libFMS.a"
   NCEPLIBS+=" ./libgfs.a"
   NCEPLIBS+=" -L${NCEP_DIR}/nceplibs/${COMPILER}/ -lbacio  -lsp_d  -lw3emc_d  -lw3nco_d"
+else
+  NCEPLIBS=${NCEP_DIR}/libFMS/${COMPILER}/${bit}/libFMS.a
 fi
 
 if [ ${CONFIG} = 'shield' ] ; then
-  (cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y ${COMP} AVX=${AVX} -f Makefile_gfs)
+  (cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y ${COMP} AVX=${AVX} PIC=${PIC} -f Makefile_gfs)
 fi
-(cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y NETCDF=3 ${COMP} AVX=${AVX} ${BIT} NCEPLIBS="${NCEPLIBS}" -f Makefile_fv3)
 
+(cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y ${COMP} AVX=${AVX} ${BIT} PIC=${PIC} NCEPLIBS="${NCEPLIBS}" -f Makefile_fv3)
+
+if [ ${CONFIG} = 'shield' ] ; then
+    (cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y NETCDF=3 ${COMP} AVX=${AVX} ${BIT} PIC=${PIC} NCEPLIBS="${NCEPLIBS}" -f Makefile_driver)
+fi
 exit 0

--- a/Build/mk_scripts/mk_make
+++ b/Build/mk_scripts/mk_make
@@ -34,6 +34,7 @@ COMPILER="intel"
 
 bit="32bit"
 comp="prod"
+pic="nopic"
 
 #
 ## parse arguments

--- a/Build/mk_scripts/mk_makefile
+++ b/Build/mk_scripts/mk_makefile
@@ -90,11 +90,20 @@ pushd exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/
 if [ ${CONFIG} = 'shield' ] ; then
   mkmf -m Makefile_gfs -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -o "-cpp" -c "${GFS_cppDefs}" \
            -p libgfs.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_gfs
-fi
 
-mkmf -m Makefile_fv3 -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "${FV3_cppDefs}" \
-         -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${NCEP_DIR}/libFMS/${COMPILER}/${BIT}" \
-          ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3
+  mkmf -m Makefile_fv3 -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" \
+           -o "-I${SHiELD_SRC}/FMS/include -I${NCEP_DIR}/libFMS/${COMPILER}/${BIT}" -c "${FV3_cppDefs}" \
+           -p libfv3.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3
+
+  mkmf -m Makefile_driver -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "${FV3_cppDefs}" \
+           -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${NCEP_DIR}/libFMS/${COMPILER}/${BIT}" \
+           ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver
+
+elif [ ${CONFIG} = 'solo' ] ; then
+  mkmf -m Makefile_fv3 -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "${FV3_cppDefs}" \
+          -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${NCEP_DIR}/libFMS/${COMPILER}/${BIT}" \
+            ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3
+fi
 
 ############################
 #---ADD LIBS TO FINAL LINK
@@ -102,6 +111,10 @@ mkmf -m Makefile_fv3 -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "${FV3_c
 sed 's/LDFLAGS/NCEPLIBS) $(LDFLAGS/g' < Makefile_fv3 > OUT
 mv OUT Makefile_fv3
 
+if [ ${CONFIG} = 'shield' ] ; then
+  sed 's/LDFLAGS/NCEPLIBS) $(LDFLAGS/g' < Makefile_driver > OUT
+  mv OUT Makefile_driver
+fi
 ############################
 #---COMPILE -O0 (for speed)
 #---GFS_diagnostics.F90

--- a/Build/mk_scripts/mk_paths
+++ b/Build/mk_scripts/mk_paths
@@ -82,11 +82,13 @@ elif [ ${CONFIG} = 'shield' ] ; then
   list_paths -o ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3 \
       SHiELD_physics/FV3GFS/ \
       atmos_drivers/SHiELD/atmos_model.F90 \
-      FMSCoupler/SHiELD/coupler_main.F90 \
       GFDL_atmos_cubed_sphere/driver/SHiELD/atmosphere.F90 \
       GFDL_atmos_cubed_sphere/tools/ \
       GFDL_atmos_cubed_sphere/model/ \
       GFDL_atmos_cubed_sphere/GFDL_tools/fv_diag_column.F90
+
+  list_paths -o ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver \
+      FMSCoupler/SHiELD/coupler_main.F90
 fi
 
 popd

--- a/site/gnu.mk
+++ b/site/gnu.mk
@@ -15,6 +15,7 @@ DEBUG =
 REPRO =
 VERBOSE =
 OPENMP =
+PIC =
 
 ##############################################
 # Need to use at least GNU Make version 3.81 #
@@ -58,6 +59,15 @@ CFLAGS += $(AVX_LEVEL)
 else
 FFLAGS += -march=native
 CFLAGS += -march-native
+endif
+
+# For some applications, namely wrapping SHiELD in Python, it can be required to
+# compile all libraries as position independent code. Setting the PIC option to
+# 'Y' with this Makefile template will enable this.
+ifeq ($(PIC),Y)
+FFLAGS += -fPIC
+CFLAGS += -fPIC
+CPPFLAGS += -fPIC
 endif
 
 FFLAGS_OPT = -O2 -fno-range-check

--- a/site/intel.mk
+++ b/site/intel.mk
@@ -15,6 +15,7 @@ DEBUG =
 REPRO =
 VERBOSE =
 OPENMP =
+PIC =
 
 ##############################################
 # Need to use at least GNU Make version 3.81 #
@@ -57,6 +58,15 @@ CFLAGS += $(AVX_LEVEL) -qno-opt-dynamic-align
 else
 FFLAGS += -xCORE-AVX-I -qno-opt-dynamic-align
 CFLAGS += -xCORE-AVX-I -qno-opt-dynamic-align
+endif
+
+# For some applications, namely wrapping SHiELD in Python, it can be required to
+# compile all libraries as position independent code. Setting the PIC option to
+# 'Y' with this Makefile template will enable this.
+ifeq ($(PIC),Y)
+FFLAGS += -fPIC
+CFLAGS += -fPIC
+CPPFLAGS += -fPIC
 endif
 
 FFLAGS_OPT = -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3

--- a/site/nvhpc.mk
+++ b/site/nvhpc.mk
@@ -15,6 +15,7 @@ DEBUG =
 REPRO =
 VERBOSE =
 OPENMP =
+PIC =
 
 ##############################################
 # Need to use at least GNU Make version 3.81 #
@@ -54,6 +55,15 @@ CFLAGS += $(AVX_LEVEL)
 else
 FFLAGS += -tp=host
 CFLAGS += -tp=host
+endif
+
+# For some applications, namely wrapping SHiELD in Python, it can be required to
+# compile all libraries as position independent code. Setting the PIC option to
+# 'Y' with this Makefile template will enable this.
+ifeq ($(PIC),Y)
+FFLAGS += -fPIC
+CFLAGS += -fPIC
+CPPFLAGS += -fPIC
 endif
 
 FFLAGS_OPT = -g -O3 -Mvect=nosse -Mnoscalarsse -Mallocatable=95


### PR DESCRIPTION
**Description**

This PR makes changes required for building a Python wrapped version of SHiELD.  It does two main things:
- It builds all code except the `coupler_main.F90` driver into static libraries, which downstream applications can link to (for now I did this only for the `shield` configuration option, but I could make a similar change for the `solo` configuration as well).
- It adds an option for build all components with position independent code, through adding a `nopic` / `pic` option to the `COMPILE`, `BUILDlibfms`, and `BUILDnceplibs` scripts, and adding an `PIC` option to the Makefile templates for the `gnu`, `intel`, and `nvhpc` compilers.

Fixes #27

**How Has This Been Tested?**

These changes have been tested in ai2cm/SHiELD-wrapper#1.  The continuous integration setup there builds the fortran model and its dependencies using the `COMPILE` script, builds the Python wrapper, and runs several tests.  An important test checks that the Python-wrapped model produces bit-for-bit identical results to the fortran executable for an identically configured run.

**Checklist:**

Please check all whether they apply or not
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
