### PR TITLE
Update CHECKOUT_code

### DIFF
--- a/CHECKOUT_code
+++ b/CHECKOUT_code
@@ -35,8 +35,8 @@ release="main"
 
 fv3_release=$release
 phy_release=$release
-fms_release="2023.02"
-drivers_release="2023.02"
+fms_release="2023.04"
+drivers_release=$release
 
 git clone -b ${fv3_release}   https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
 git clone -b ${phy_release}   https://github.com/NOAA-GFDL/SHiELD_physics

--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ The top level directory structure groups source code and input files as follow:
 | --------------       | ------- |
 | ```LICENSE.md```     | copy of the Gnu Lesser General Public license, version 3 |
 | ```README.md```      | this file with basic pointers to more information |
-| ```CHECKOUT_code```  | script to download necessary source for proper build GFDL's SHield and FV3 Solo models |
+| ```CHECKOUT_code```  | script to download necessary source for proper build GFDL's SHield and FV3 Solo models <sup>*</sup>|
 | ```Build/```         | contains scripts used for building models listed above |
 | ```mkmf/```          | submodule entry point for the externally managed [mkmf software](https://github.com/NOAA-GFDL/mkmf) |
 | ```RTS/```           | contains scripts for use in CI software regression testing (see [RTS/README.md](https://github.com/NOAA-GFDL/SHiELD_build/blob/main/RTS/README.md))|
 | ```site/```          | contains site specific scripts and compiler make templates |
+
+<sup>*</sup>By default, ```CHECKOUT_code``` checks out the latest main branch from each repository, which may include experimental features
 
 # Compiling
 


### PR DESCRIPTION
**Description**

SHiELD_build fails to compile the model out-of-the-box because outdated codes were checked out. Resolved the issue by revising the tags used for code checkout.

**How Has This Been Tested?**

Tested on Gaea and Stellar without issues.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
