### PR TITLE
Build SHiELD with the full FMSCoupler and SHiEMOM (SHIELD+MOM6)

### DIFF
--- a/Build/BUILDmom6
+++ b/Build/BUILDmom6
@@ -1,0 +1,113 @@
+#!/bin/bash
+#***********************************************************************
+#*                   GNU Lesser General Public License
+#*
+#* This file is part of the SHiELD Build System.
+#*
+#* The SHiELD Build System free software: you can redistribute it
+#* and/or modify it under the terms of the
+#* GNU Lesser General Public License as published by the
+#* Free Software Foundation, either version 3 of the License, or
+#* (at your option) any later version.
+#*
+#* The SHiELD Build System distributed in the hope that it will be
+#* useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+#* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#* See the GNU General Public License for more details.
+#*
+#* You should have received a copy of the GNU Lesser General Public
+#* License along with theSHiELD Build System
+#* If not, see <http://www.gnu.org/licenses/>.
+#***********************************************************************
+#
+#  DISCLAIMER: This script is provided as-is and as such is unsupported.
+#
+set -x
+#
+# set default values
+# configure your build parameters
+  COMPILER="intel"
+  BIT="64bit"
+#
+# parse arguments
+  for arg in "$@"
+  do
+      case $arg in
+          intel|gnu|nvhpc)
+             COMPILER="${arg#*=}"
+             shift # Remove "compiler" from processing
+             ;;
+	  32bit|64bit)
+             BIT="${arg#*=}"
+             shift # Remove *bit from processing
+             ;;
+          *)
+          if [ ${arg#} != '--help' ] && [ ${arg#} != '-h' ] ; then
+            echo "option "${arg#}" not found"
+          fi
+          echo -e ' '
+          echo -e "valid options are:"
+          echo -e "\t[intel(D) | gnu | nvhpc] \t\t\t compiler"
+	  echo -e "\t[32bit(D) | 64bit] \t\t\t FV3 precision option"
+          echo -e "\n"
+          exit
+          ;;
+      esac
+  done
+
+#
+# set up some default variables if not called from COMPILE
+# BUILD_ROOT is set if this script is called from the COMPILE script
+if [ -z ${BUILD_ROOT} ] ; then
+   export BUILD_ROOT=${PWD%/*}
+   export SHiELD_SRC=${PWD%/*/*}/SHiELD_SRC/
+   export PATH="${BUILD_ROOT}/mkmf/bin:${BUILD_ROOT}/Build/mk_scripts:${PATH}"
+   export NCEP_DIR=${BUILD_ROOT}/Build
+   if [ ! -z ${EXTERNAL_LIBS} ] ; then
+      export NCEP_DIR=${EXTERNAL_LIBS}
+   fi
+   # load the proper environment for your machine
+   . ${BUILD_ROOT}/site/environment.${COMPILER}.sh
+fi
+
+export mkmf_template="/ncrc/home2/fms/local/opt/fre-commands/bronx-20/site/ncrc5/intel-classic.mk" #GAEA
+export mkmf_template="/ncrc/home2/fms/local/opt/fre-commands/bronx-21/site/ncrc5/intel-classic.mk" #GAEA
+#export mkmf_template="/home/jmoualle/workdir/newshieldfull/SHiELD_build/site/intel.mk" #ORION
+
+#source /ncrc/home2/Joseph.Mouallem/mom6/build/env.cshrc
+
+mkdir -p ${BUILD_ROOT}/Build/mom6
+list_paths -l -o ${BUILD_ROOT}/Build/mom6/pathnames_mom6 \
+    ${SHiELD_SRC}/mom6/src/MOM6/config_src/memory/dynamic_nonsymmetric \
+    ${SHiELD_SRC}/mom6/src/MOM6/config_src/drivers/FMS_cap \
+    ${SHiELD_SRC}/mom6/src/MOM6/src/*/ \
+    ${SHiELD_SRC}/mom6/src/MOM6/src/*/*/ \
+    ${SHiELD_SRC}/mom6/src/MOM6/config_src/external/ODA_hooks \
+    ${SHiELD_SRC}/mom6/src/MOM6/config_src/external/database_comms \
+    ${SHiELD_SRC}/mom6/src/MOM6/config_src/external/drifters \
+    ${SHiELD_SRC}/mom6/src/MOM6/config_src/external/stochastic_physics \
+    ${SHiELD_SRC}/mom6/src/MOM6/config_src/infra/FMS2 \
+    ${SHiELD_SRC}/ocean_BGC/generic_tracers \
+    ${SHiELD_SRC}/ocean_BGC/mocsy/src \
+    ${SHiELD_SRC}/mom6/src/MOM6/pkg/GSW-Fortran/*/ \
+    ${SHiELD_SRC}/mom6/src/MOM6/config_src/infra/FMS2
+cd ${BUILD_ROOT}/Build
+pushd mom6
+mkmf -m Makefile -a ${SHiELD_SRC} -p libmom6.a -t ${mkmf_template} -c "-DINTERNAL_FILE_NML -g -DMAX_FIELDS_=100 -DNOT_SET_AFFINITY -D_USE_MOM6_DIAG -D_USE_GENERIC_TRACER -DUSE_PRECISION=2 -I${NCEP_DIR}/libFMS/${COMPILER}/${BIT}" -I${SHiELD_SRC}/FMS/axis_utils/include -I${SHiELD_SRC}/FMS/diag_manager/include -I${SHiELD_SRC}/FMS/fms/include -I${SHiELD_SRC}/FMS/fms2_io/include -I${SHiELD_SRC}/FMS/horiz_interp/include -I${SHiELD_SRC}/FMS/include -I${SHiELD_SRC}/FMS/mpp/include -I${SHiELD_SRC}/FMS/sat_vapor_pres/include -I${SHiELD_SRC}/FMS/string_utils/include -I${SHiELD_SRC}/FMS/test_fms/fms/include -I${SHiELD_SRC}/mom6/src/MOM6/pkg/CVMix-src/include -I${SHiELD_SRC}/mom6/src/MOM6/src/framework ${BUILD_ROOT}/Build/mom6/pathnames_mom6
+
+# to run on orion, git-version-string will create somthing like 'ref:xxxx' for D_FILE_verion which will crash a file compilation in mom6
+#mkmf -m Makefile -a ${SHiELD_SRC} -p libmom6.a -t ${mkmf_template} -c "-DINTERNAL_FILE_NML -g -DMAX_FIELDS_=100 -DNOT_SET_AFFINITY -D_USE_MOM6_DIAG -D_USE_GENERIC_TRACER -DUSE_PRECISION=2 -D_FILE_VERSION="'"`git-version-string $<`"'"" -o "-I${NCEP_DIR}/libFMS/${COMPILER}/${BIT}" -I${SHiELD_SRC}/FMS/axis_utils/include -I${SHiELD_SRC}/FMS/diag_manager/include -I${SHiELD_SRC}/FMS/fms/include -I${SHiELD_SRC}/FMS/fms2_io/include -I${SHiELD_SRC}/FMS/horiz_interp/include -I${SHiELD_SRC}/FMS/include -I${SHiELD_SRC}/FMS/mpp/include -I${SHiELD_SRC}/FMS/sat_vapor_pres/include -I${SHiELD_SRC}/FMS/string_utils/include -I${SHiELD_SRC}/FMS/test_fms/fms/include -I${SHiELD_SRC}/mom6/src/MOM6/pkg/CVMix-src/include -I${SHiELD_SRC}/mom6/src/MOM6/src/framework ${BUILD_ROOT}/Build/mom6/pathnames_mom6
+make -j8 REPRO=Y OPENMP=Y AVX=Y NETCDF=3 Makefile libmom6.a >& Build_mom6.out
+
+################
+#will get noise with openmp in debugmode
+################
+
+# test and report on libFMS build success
+if [ $? -ne 0 ] ; then
+  echo ">>> ${BUILD_ROOT}/Build/mom6 build failed"
+  exit 1
+fi
+echo " libmom6 build successful"
+
+popd

--- a/Build/BUILDsis2
+++ b/Build/BUILDsis2
@@ -1,0 +1,101 @@
+#!/bin/bash
+#***********************************************************************
+#*                   GNU Lesser General Public License
+#*
+#* This file is part of the SHiELD Build System.
+#*
+#* The SHiELD Build System free software: you can redistribute it
+#* and/or modify it under the terms of the
+#* GNU Lesser General Public License as published by the
+#* Free Software Foundation, either version 3 of the License, or
+#* (at your option) any later version.
+#*
+#* The SHiELD Build System distributed in the hope that it will be
+#* useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+#* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#* See the GNU General Public License for more details.
+#*
+#* You should have received a copy of the GNU Lesser General Public
+#* License along with theSHiELD Build System
+#* If not, see <http://www.gnu.org/licenses/>.
+#***********************************************************************
+#
+#  DISCLAIMER: This script is provided as-is and as such is unsupported.
+#
+set -x
+#
+# set default values
+# configure your build parameters
+  COMPILER="intel"
+  BIT="64bit"
+#
+# parse arguments
+  for arg in "$@"
+  do
+      case $arg in
+          intel|gnu|nvhpc)
+             COMPILER="${arg#*=}"
+             shift # Remove "compiler" from processing
+             ;;
+	  32bit|64bit)
+             BIT="${arg#*=}"
+             shift # Remove *bit from processing
+             ;;
+          *)
+          if [ ${arg#} != '--help' ] && [ ${arg#} != '-h' ] ; then
+            echo "option "${arg#}" not found"
+          fi
+          echo -e ' '
+          echo -e "valid options are:"
+          echo -e "\t[intel(D) | gnu | nvhpc] \t\t\t compiler"
+	  echo -e "\t[32bit(D) | 64bit] \t\t\t FV3 precision option"
+          echo -e "\n"
+          exit
+          ;;
+      esac
+  done
+
+#
+# set up some default variables if not called from COMPILE
+# BUILD_ROOT is set if this script is called from the COMPILE script
+if [ -z ${BUILD_ROOT} ] ; then
+   export BUILD_ROOT=${PWD%/*}
+   export SHiELD_SRC=${PWD%/*/*}/SHiELD_SRC/
+   export PATH="${BUILD_ROOT}/mkmf/bin:${BUILD_ROOT}/Build/mk_scripts:${PATH}"
+   export NCEP_DIR=${BUILD_ROOT}/Build
+   if [ ! -z ${EXTERNAL_LIBS} ] ; then
+      export NCEP_DIR=${EXTERNAL_LIBS}
+   fi
+   # load the proper environment for your machine
+   . ${BUILD_ROOT}/site/environment.${COMPILER}.sh
+fi
+
+export mkmf_template="/ncrc/home2/fms/local/opt/fre-commands/bronx-20/site/ncrc5/intel-classic.mk" #GAEA
+#export mkmf_template="/home/jmoualle/workdir/newshieldfull/SHiELD_build/site/intel.mk" #ORION
+
+mkdir -p ${BUILD_ROOT}/Build/sis2
+list_paths -l -o ${BUILD_ROOT}/Build/sis2/pathnames_sis2 \
+    ${SHiELD_SRC}/mom6/src/SIS2/config_src/dynamic_symmetric \
+    ${SHiELD_SRC}/mom6/src/SIS2/config_src/external/Icepack_interfaces \
+    ${SHiELD_SRC}/mom6/src/SIS2/src \
+    ${SHiELD_SRC}/mom6/src/icebergs/src \
+    ${SHiELD_SRC}/ice_param 
+
+cd ${BUILD_ROOT}/Build
+pushd sis2
+mkmf -m Makefile -a ${SHiELD_SRC} -p libsis2.a -t ${mkmf_template} -c "-DINTERNAL_FILE_NML -g -DUSE_FMS2_IO -I${NCEP_DIR}/mom6 -I${NCEP_DIR}/libFMS/${COMPILER}/${BIT}" -I${SHiELD_SRC}/FMS/axis_utils/include -I${SHiELD_SRC}/FMS/diag_manager/include -I${SHiELD_SRC}/FMS/fms/include -I${SHiELD_SRC}/FMS/fms2_io/include -I${SHiELD_SRC}/FMS/horiz_interp/include -I${SHiELD_SRC}/FMS/include -I${SHiELD_SRC}/FMS/mpp/include -I${SHiELD_SRC}/FMS/sat_vapor_pres/include -I${SHiELD_SRC}/FMS/string_utils/include -I${SHiELD_SRC}/FMS/test_fms/fms/include -I${SHiELD_SRC}/mom6/src/MOM6/pkg/CVMix-src/include -I${SHiELD_SRC}/mom6/src/MOM6/src/framework ${BUILD_ROOT}/Build/sis2/pathnames_sis2
+
+
+# to run on orion, git-version-string will create somthing like 'ref:xxxx' for D_FILE_verion which will crash a file compilation in mom6
+#mkmf -m Makefile -a ${SHiELD_SRC} -p libmom6.a -t ${mkmf_template} -c "-DINTERNAL_FILE_NML -g -DMAX_FIELDS_=100 -DNOT_SET_AFFINITY -D_USE_MOM6_DIAG -D_USE_GENERIC_TRACER -DUSE_PRECISION=2 -D_FILE_VERSION="'"`git-version-string $<`"'"" -o "-I${NCEP_DIR}/libFMS/${COMPILER}/${BIT}" -I${SHiELD_SRC}/FMS/axis_utils/include -I${SHiELD_SRC}/FMS/diag_manager/include -I${SHiELD_SRC}/FMS/fms/include -I${SHiELD_SRC}/FMS/fms2_io/include -I${SHiELD_SRC}/FMS/horiz_interp/include -I${SHiELD_SRC}/FMS/include -I${SHiELD_SRC}/FMS/mpp/include -I${SHiELD_SRC}/FMS/sat_vapor_pres/include -I${SHiELD_SRC}/FMS/string_utils/include -I${SHiELD_SRC}/FMS/test_fms/fms/include -I${SHiELD_SRC}/mom6/src/MOM6/pkg/CVMix-src/include -I${SHiELD_SRC}/mom6/src/MOM6/src/framework ${BUILD_ROOT}/Build/mom6/pathnames_mom6
+make -j8  REPRO=Y OPENMP=Y AVX=Y NETCDF=3 Makefile libsis2.a >& Build_sis2.out
+
+#
+# test and report on libsis2 build success
+if [ $? -ne 0 ] ; then
+  echo ">>> ${BUILD_ROOT}/Build/sis2 build failed"
+  exit 1
+fi
+echo " libsis2 build successful"
+
+popd

--- a/Build/COMPILE
+++ b/Build/COMPILE
@@ -65,7 +65,7 @@ spin()
   for arg in "$@"
   do
       case $arg in
-          shield|solo)
+          shield|solo|shieldfull|shiemom)
              config="${arg#*=}"
              if [ $config = 'solo' ] ; then
                config_name="SOLO"
@@ -102,7 +102,7 @@ spin()
                sleep 20
              fi
              ;;
-          noclean|clean|cleanall)
+          noclean|clean|cleanmom|cleanall)
              clean="${arg#*=}"
              shift # Remove "clean" from processing
              ;;
@@ -193,10 +193,17 @@ fi
      \rm -rf libFMS/${compiler}/*
      \rm -rf exec/${config}_${hydro}.${comp}.${bit}.${compiler}/*
      \rm -rf nceplibs/${compiler}/*
+     \rm -rf mom6/*
+     \rm -rf sis2/*
   elif [ ${clean} = "clean" ] ; then
      echo " cleaning build directory in 2 seconds"
      sleep 2
      \rm -rf exec/${config}_${hydro}.${comp}.${bit}.${compiler}/*
+  elif [ ${clean} = "cleanmom" ] ; then
+     echo " cleaning build directory in 2 seconds"
+     sleep 2
+     \rm -rf mom6/*
+     \rm -rf sis2/*
   fi
 
 # If EXTERNAL_LIBS is set, then the program will use the path defined by
@@ -231,6 +238,18 @@ fi
         exit 3
      fi
   fi
+
+if [ $config = "shiemom" ] ; then
+# from lauren
+  # I think mom6 needs to be built in 64bit for now?
+  # I can only get it to compiler with 64bit FMS
+  ./BUILDmom6 ${compiler} ${bit}
+     echo "DONE WITH MOM6"
+
+# for sis2
+  ./BUILDsis2 ${compiler} ${bit}
+     echo "DONE WITH SIS2"
+fi
 
 #
 # ensure the build and final executable locations are available

--- a/Build/mk_scripts/mk_make
+++ b/Build/mk_scripts/mk_make
@@ -41,7 +41,7 @@ pic="nopic"
 for arg in "$@"
 do
     case $arg in
-        shield|solo)
+        shield|solo|shieldfull|shiemom)
           CONFIG="${arg#*=}"
           shift # Remove CONFIG from processing
           ;;
@@ -90,22 +90,29 @@ module list
 
 $FC --version
 
-if [ ${CONFIG} = 'shield' ] ; then
+if [ ${CONFIG} = 'shield' ] || [ ${CONFIG} = 'shieldfull' ] ; then
   NCEPLIBS="./libfv3.a"
   NCEPLIBS+=" ${NCEP_DIR}/libFMS/${COMPILER}/${bit}/libFMS.a"
   NCEPLIBS+=" ./libgfs.a"
   NCEPLIBS+=" -L${NCEP_DIR}/nceplibs/${COMPILER}/ -lbacio  -lsp_d  -lw3emc_d  -lw3nco_d"
-else
+elif [ ${CONFIG} = 'solo'  ] ; then
   NCEPLIBS=${NCEP_DIR}/libFMS/${COMPILER}/${bit}/libFMS.a
+elif [ ${CONFIG} = 'shiemom'  ] ; then
+  NCEPLIBS="./libfv3.a"
+  NCEPLIBS+=" ${NCEP_DIR}/sis2/libsis2.a"
+  NCEPLIBS+=" ${NCEP_DIR}/mom6/libmom6.a"
+  NCEPLIBS+=" ${NCEP_DIR}/libFMS/${COMPILER}/${bit}/libFMS.a"
+  NCEPLIBS+=" ./libgfs.a"
+  NCEPLIBS+=" -L${NCEP_DIR}/nceplibs/${COMPILER}/ -lbacio  -lsp_d  -lw3emc_d  -lw3nco_d"
 fi
 
-if [ ${CONFIG} = 'shield' ] ; then
+if [ ${CONFIG} = 'shield' ] ||  [ ${CONFIG} = 'shieldfull' ] || [ ${CONFIG} = 'shiemom' ]  ; then
   (cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y ${COMP} AVX=${AVX} PIC=${PIC} -f Makefile_gfs)
 fi
 
-(cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y ${COMP} AVX=${AVX} ${BIT} PIC=${PIC} NCEPLIBS="${NCEPLIBS}" -f Makefile_fv3)
+(cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y NETCDF=3 ${COMP} AVX=${AVX} ${BIT} PIC=${PIC} NCEPLIBS="${NCEPLIBS}" -f Makefile_fv3)
 
-if [ ${CONFIG} = 'shield' ] ; then
-    (cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y NETCDF=3 ${COMP} AVX=${AVX} ${BIT} PIC=${PIC} NCEPLIBS="${NCEPLIBS}" -f Makefile_driver)
+if [ ${CONFIG} = 'shield' ] ||  [ ${CONFIG} = 'shieldfull' ] || [ ${CONFIG} = 'shiemom' ] ; then
+   (cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y NETCDF=3 ${COMP} AVX=${AVX} ${BIT} PIC=${PIC} NCEPLIBS="${NCEPLIBS}" -f Makefile_driver)
 fi
 exit 0

--- a/Build/mk_scripts/mk_makefile
+++ b/Build/mk_scripts/mk_makefile
@@ -36,7 +36,7 @@ COMPILER="intel"
 for arg in "$@"
 do
     case $arg in
-        shield|solo)
+        shield|solo|shieldfull|shiemom)
         CONFIG="${arg#*=}"
         shift # Remove CONFIG from processing
         ;;
@@ -70,6 +70,8 @@ GFS_cppDefs="-DNEW_TAUCTMAX -DNEMS_GSM -DINTERNAL_FILE_NML"
 FV3_cppDefs="-Duse_libMPI -Duse_netCDF -DHAVE_SCHED_GETAFFINITY -DSPMD -Duse_LARGEFILE -DINTERNAL_FILE_NML"
 if [ ${CONFIG} = 'shield' ] ; then
   FV3_cppDefs+=" -DGFS_PHYS -DUSE_GFSL63"
+elif [ ${CONFIG} = 'shieldfull' ] || [ ${CONFIG} = 'shiemom' ]  ; then
+  FV3_cppDefs+=" -DGFS_PHYS -DUSE_GFSL63 -D_USE_LEGACY_LAND_ -DLAND_GRID_FROM_ATMOS"
 elif [ ${CONFIG} = 'solo' ] ; then
   FV3_cppDefs+=" -DDCMIP -DDYCORE_SOLO -DHIWPP"
 fi
@@ -87,7 +89,7 @@ pushd exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/
 ############################
 #---CREATE MAKEFILES
 ############################
-if [ ${CONFIG} = 'shield' ] ; then
+if [ ${CONFIG} = 'shield' ] || [ ${CONFIG} = 'shieldfull' ]  ; then
   mkmf -m Makefile_gfs -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -o "-cpp" -c "${GFS_cppDefs}" \
            -p libgfs.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_gfs
 
@@ -97,6 +99,19 @@ if [ ${CONFIG} = 'shield' ] ; then
 
   mkmf -m Makefile_driver -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "${FV3_cppDefs}" \
            -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${NCEP_DIR}/libFMS/${COMPILER}/${BIT}" \
+           ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver
+
+
+elif [ ${CONFIG} = 'shiemom' ] ; then
+  mkmf -m Makefile_gfs -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -o "-cpp" -c "${GFS_cppDefs}" \
+           -p libgfs.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_gfs
+
+  mkmf -m Makefile_fv3 -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" \
+           -o "-I${SHiELD_SRC}/FMS/include -I${NCEP_DIR}/libFMS/${COMPILER}/${BIT}" -c "${FV3_cppDefs}" \
+           -p libfv3.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3
+
+  mkmf -m Makefile_driver -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "${FV3_cppDefs}" \
+           -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${NCEP_DIR}/libFMS/${COMPILER}/${BIT} -I${NCEP_DIR}/mom6 -I${NCEP_DIR}/sis2" \
            ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver
 
 elif [ ${CONFIG} = 'solo' ] ; then
@@ -111,7 +126,7 @@ fi
 sed 's/LDFLAGS/NCEPLIBS) $(LDFLAGS/g' < Makefile_fv3 > OUT
 mv OUT Makefile_fv3
 
-if [ ${CONFIG} = 'shield' ] ; then
+if [ ${CONFIG} = 'shield' ] ||  [ ${CONFIG} = 'shieldfull' ] || [ ${CONFIG} = 'shiemom' ] ; then
   sed 's/LDFLAGS/NCEPLIBS) $(LDFLAGS/g' < Makefile_driver > OUT
   mv OUT Makefile_driver
 fi
@@ -119,7 +134,7 @@ fi
 #---COMPILE -O0 (for speed)
 #---GFS_diagnostics.F90
 ############################
-if [ ${CONFIG} = 'shield' ] ; then
+if [ ${CONFIG} = 'shield' ] ||  [ ${CONFIG} = 'shieldfull' ]  || [ ${CONFIG} = 'shiemom' ] ; then
   sed -i 's"$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) $(OTHERFLAGS) $(OTHER_FFLAGS) -c\t$(SRCROOT)SHiELD_physics/GFS_layer/GFS_diagnostics.F90" $(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) $(OTHERFLAGS) $(OTHER_FFLAGS) -O0 -c\t$(SRCROOT)SHiELD_physics/GFS_layer/GFS_diagnostics.F90" ' Makefile_gfs
 fi
 

--- a/Build/mk_scripts/mk_paths
+++ b/Build/mk_scripts/mk_paths
@@ -34,7 +34,7 @@ COMPILER="intel"
 for arg in "$@"
 do
     case $arg in
-        shield|solo)
+        shield|solo|shieldfull|shiemom)
         CONFIG="${arg#*=}"
         shift # Remove CONFIG from processing
         ;;
@@ -89,6 +89,55 @@ elif [ ${CONFIG} = 'shield' ] ; then
 
   list_paths -o ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver \
       FMSCoupler/SHiELD/coupler_main.F90
+
+elif [ ${CONFIG} = 'shieldfull' ] ; then
+  list_paths -o ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_gfs \
+      GFDL_atmos_cubed_sphere/model/gfdl_cld_mp.F90 \
+      GFDL_atmos_cubed_sphere/model/cld_eff_rad.F90 \
+      SHiELD_physics/gsmphys/  \
+      SHiELD_physics/GFS_layer/ \
+      SHiELD_physics/IPD_layer/
+
+  list_paths -o ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3 \
+      SHiELD_physics/FV3GFS/ \
+      GFDL_atmos_cubed_sphere/tools/ \
+      GFDL_atmos_cubed_sphere/model/ \
+      GFDL_atmos_cubed_sphere/GFDL_tools/fv_diag_column.F90 \
+      atmos_null/ \
+      ocean_null/ \
+      ice_null/ \
+      ice_param/ \
+      land_null/
+
+  list_paths -o ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver \
+      atmos_drivers/SHiELDFULL/atmos_model.F90 \
+      GFDL_atmos_cubed_sphere/driver/SHiELDFULL/atmosphere.F90 \
+      FMSCoupler/full/ \
+      FMSCoupler/shared/
+
+elif  [ ${CONFIG} = 'shiemom' ] ; then
+
+  list_paths -o ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_gfs \
+      GFDL_atmos_cubed_sphere/model/gfdl_cld_mp.F90 \
+      GFDL_atmos_cubed_sphere/model/cld_eff_rad.F90 \
+      SHiELD_physics/gsmphys/  \
+      SHiELD_physics/GFS_layer/ \
+      SHiELD_physics/IPD_layer/
+
+  list_paths -o ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3 \
+      SHiELD_physics/FV3GFS/ \
+      GFDL_atmos_cubed_sphere/tools/ \
+      GFDL_atmos_cubed_sphere/model/ \
+      GFDL_atmos_cubed_sphere/GFDL_tools/fv_diag_column.F90 \
+      atmos_null/ \
+      land_null/
+
+  list_paths -o ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver \
+      atmos_drivers/shiemom/atmos_model.F90 \
+      GFDL_atmos_cubed_sphere/driver/SHiELDFULL/atmosphere.F90 \
+      FMSCoupler/full/ \
+      FMSCoupler/shared/
+
 fi
 
 popd

--- a/CHECKOUT_code
+++ b/CHECKOUT_code
@@ -32,17 +32,44 @@ mkdir -p ${SHiELD_SRC}
 cd ${SHiELD_SRC}
 
 release="main"
+release="shiemom"
+
+#fv3_release=$release
+#phy_release=$release
+#fms_release="2023.04"
+#drivers_release=$release
+#
+#git clone -b ${fv3_release}   https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
+#git clone -b ${phy_release}   https://github.com/NOAA-GFDL/SHiELD_physics
+#git clone -b ${fms_release}   https://github.com/NOAA-GFDL/FMS
+#git clone -b ${fms_release}   https://github.com/NOAA-GFDL/FMSCoupler
+#git clone -b ${drivers_release}   https://github.com/NOAA-GFDL/atmos_drivers
+
+
 
 fv3_release=$release
 phy_release=$release
-fms_release="2023.04"
-drivers_release=$release
+fms_release="$release"
+drivers_release="$release"
+atmosnull_release="$release"
+ocean_release="$release"
+land_release="$release"
+ice_release="$release"
 
-git clone -b ${fv3_release}   https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
-git clone -b ${phy_release}   https://github.com/NOAA-GFDL/SHiELD_physics
-git clone -b ${fms_release}   https://github.com/NOAA-GFDL/FMS
-git clone -b ${fms_release}   https://github.com/NOAA-GFDL/FMSCoupler
-git clone -b ${drivers_release}   https://github.com/NOAA-GFDL/atmos_drivers
+git clone -b ${fv3_release}   https://github.com/JosephMouallem/GFDL_atmos_cubed_sphere
+git clone -b ${phy_release}   https://github.com/JosephMouallem/SHiELD_physics
+git clone -b ${fms_release}   https://github.com/JosephMouallem/FMS
+git clone -b ${fms_release}   https://github.com/JosephMouallem/FMSCoupler
+git clone -b ${drivers_release}   https://github.com/JosephMouallem/atmos_drivers
+git clone -b ${atmosnull_release}   https://github.com/JosephMouallem/atmos_null
+git clone -b ${ocean_release}   https://github.com/JosephMouallem/ocean_null
+git clone -b ${land_release}   https://github.com/JosephMouallem/land_null
+git clone -b ${ice_release}   https://github.com/JosephMouallem/ice_null
+git clone  https://github.com/NOAA-GFDL/ice_param
+
 
 #Automatic release tracking from Matt M.
 echo $release > release
+
+cd ../SHiELD_build/
+./CHECKOUT_mom6.csh

--- a/CHECKOUT_mom6.csh
+++ b/CHECKOUT_mom6.csh
@@ -1,0 +1,65 @@
+#!/bin/tcsh -f
+
+source $MODULESHOME/init/csh
+
+cd ../SHiELD_SRC/
+echo `pwd`
+
+
+
+# ---------------- component 'mom6'
+echo "Cloning https://github.com/NOAA-GFDL/ocean_BGC.git on branch/tag master"
+set git_output=`git clone -q --recursive -b master https://github.com/NOAA-GFDL/ocean_BGC.git >& /dev/stdout`
+if ( $? != 0 ) then
+     echo "$git_output" | sed 's/^/**GIT ERROR** /' > /dev/stderr
+     exit 1
+endif
+# Additional checkout commands from XML file
+
+          ( cd ocean_BGC && git checkout 2023.01 )
+          git clone -b dev/gfdl https://github.com/NOAA-GFDL/MOM6-examples.git mom6
+          pushd mom6
+          git checkout 3220014e
+          git submodule update --recursive --init src/MOM6 src/SIS2 src/icebergs
+          (cd src/icebergs && git checkout dev/gfdl)
+          if ("fffb6f35" != "") then
+            echo WARNING: Checking out from a fork! Work in progress
+            (cd src/MOM6;git checkout fffb6f35; )
+          endif
+          if ("fac2ec43" != "") then
+            echo WARNING: Checking out from a fork! Work in progress
+            (cd src/SIS2;git checkout fac2ec43; )
+          endif
+          popd
+
+          pushd mom6
+          set platform_domain = `perl -T -e "use Net::Domain(hostdomain) ; print hostdomain"`
+          if ("${platform_domain}" =~ *"MsState"* ) then
+            ln -s /work/noaa/gfdlscr/pdata/gfdl/gfdl_O/datasets/ .datasets
+          else
+            ln -s /lustre/f2/pdata/gfdl/gfdl_O/datasets/ .datasets
+          endif
+          popd
+
+          test -e mom6/.datasets
+          if ($status != 0) then
+            echo ""; echo "" ; echo "   WARNING:  .datasets link in MOM6 examples directory is invalid"; echo ""; echo ""
+          endif
+
+          git clone https://gitlab.gfdl.noaa.gov/ogrp/Gaea-stats-MOM6-examples.git
+          pushd Gaea-stats-MOM6-examples/regressions/ice_ocean_SIS2
+          foreach stat ( `find . -name "ocean.stats.*"` )
+            cp $stat ../../../mom6/ice_ocean_SIS2/$stat
+          end
+          popd
+
+
+## ---------------- component 'sis2'
+#echo "Cloning https://github.com/NOAA-GFDL/ice_param.git on branch/tag 2021.03"
+#set git_output=`git clone -q --recursive -b 2021.03 https://github.com/NOAA-GFDL/ice_param.git >& /dev/stdout`
+#if ( $? != 0 ) then
+#     echo "$git_output" | sed 's/^/**GIT ERROR** /' > /dev/stderr
+#     exit 1
+#endif
+## Additional checkout commands from XML file
+

--- a/README.md
+++ b/README.md
@@ -23,8 +23,15 @@ The top level directory structure groups source code and input files as follow:
 Be sure to download the mkmf submodule prior to beginning.  To use:
 
  1) checkout code via CHECKOUT_code script
+    - ./CHECKOUT_code will checkout necessary files for shields (running with either simple or full coupler)
+    - ./CHECKOUT_code will automatically run ./CHECKOUT_mom6 for mom6/sis2 files
+
  2) cd Build and execute ./COMPILE script with the --help option to see usage
- 3) sample compile:  ./COMPILE shield nh repro 32bit intel
+
+ 3) a) ./COMPILE shield:     will compile shield with simple coupler
+    b) ./COMPILE shieldfull: will compile shield with full coupler (utilizing null modules for ocean, land, ice)
+    c) ./COMPILE shiemom:    will compile mom6, sis2, fv3, gfs as libraries and link them to the full coupler (no null ocean and ice modules.)
+ Example: sample compile:  ./COMPILE shield nh repro 32bit intel
 
 # Disclaimer
 


### PR DESCRIPTION
This PR allows building SHiELD with the full coupler from FMSCoupler.
A new compile option 'shieldfull' is added to allow that functionality.
The old shield coupler is still maintained when compiling with the option 'shield' (still the default option).

This PR also allows checking out MOM/SIS2 files and compiling them as libraries then linking them to SHiELD.
The new model is called SHiEMOM.
Check for new driver files in the repos of atmos_drivers and FV3.


Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
