### PR TITLE
remove extra checked out and compiled files for ocean/ice components

### DIFF
--- a/Build/BUILDmom6
+++ b/Build/BUILDmom6
@@ -74,19 +74,17 @@ fi
 
 mkdir -p ${BUILD_ROOT}/Build/mom6
 list_paths -l -o ${BUILD_ROOT}/Build/mom6/pathnames_mom6 \
-    ${SHiELD_SRC}/mom6/src/MOM6/config_src/memory/dynamic_nonsymmetric \
-    ${SHiELD_SRC}/mom6/src/MOM6/config_src/drivers/FMS_cap \
-    ${SHiELD_SRC}/mom6/src/MOM6/src/*/ \
-    ${SHiELD_SRC}/mom6/src/MOM6/src/*/*/ \
-    ${SHiELD_SRC}/mom6/src/MOM6/config_src/external/ODA_hooks \
-    ${SHiELD_SRC}/mom6/src/MOM6/config_src/external/database_comms \
-    ${SHiELD_SRC}/mom6/src/MOM6/config_src/external/drifters \
-    ${SHiELD_SRC}/mom6/src/MOM6/config_src/external/stochastic_physics \
-    ${SHiELD_SRC}/mom6/src/MOM6/config_src/infra/FMS2 \
-    ${SHiELD_SRC}/ocean_BGC/generic_tracers \
-    ${SHiELD_SRC}/ocean_BGC/mocsy/src \
-    ${SHiELD_SRC}/mom6/src/MOM6/pkg/GSW-Fortran/*/ \
-    ${SHiELD_SRC}/mom6/src/MOM6/config_src/infra/FMS2
+    ${SHiELD_SRC}/MOM6/config_src/memory/dynamic_nonsymmetric \
+    ${SHiELD_SRC}/MOM6/config_src/drivers/FMS_cap \
+    ${SHiELD_SRC}/MOM6/src/*/ \
+    ${SHiELD_SRC}/MOM6/src/*/*/ \
+    ${SHiELD_SRC}/MOM6/config_src/external/ODA_hooks \
+    ${SHiELD_SRC}/MOM6/config_src/external/database_comms \
+    ${SHiELD_SRC}/MOM6/config_src/external/drifters \
+    ${SHiELD_SRC}/MOM6/config_src/external/stochastic_physics \
+    ${SHiELD_SRC}/MOM6/config_src/external/GFDL_ocean_BGC \
+    ${SHiELD_SRC}/MOM6/pkg/GSW-Fortran/*/ \
+    ${SHiELD_SRC}/MOM6/config_src/infra/FMS2
 cd ${BUILD_ROOT}/Build
 
 pushd mom6
@@ -95,10 +93,10 @@ mkmf -m Makefile -a ${SHiELD_SRC} -p libmom6.a -t "${BUILD_ROOT}/${TEMPLATE}" \
      -c "-DINTERNAL_FILE_NML -g -DMAX_FIELDS_=100 -DNOT_SET_AFFINITY -D_USE_MOM6_DIAG -D_USE_GENERIC_TRACER -DUSE_PRECISION=2 -I${NCEP_DIR}/libFMS/${COMPILER}/${BIT}" \
      -I${SHiELD_SRC}/FMS/axis_utils/include -I${SHiELD_SRC}/FMS/diag_manager/include -I${SHiELD_SRC}/FMS/fms/include -I${SHiELD_SRC}/FMS/fms2_io/include \
      -I${SHiELD_SRC}/FMS/horiz_interp/include -I${SHiELD_SRC}/FMS/include -I${SHiELD_SRC}/FMS/mpp/include -I${SHiELD_SRC}/FMS/sat_vapor_pres/include \
-     -I${SHiELD_SRC}/FMS/string_utils/include -I${SHiELD_SRC}/FMS/test_fms/fms/include -I${SHiELD_SRC}/mom6/src/MOM6/pkg/CVMix-src/include \
-     -I${SHiELD_SRC}/mom6/src/MOM6/src/framework ${BUILD_ROOT}/Build/mom6/pathnames_mom6
+     -I${SHiELD_SRC}/FMS/string_utils/include -I${SHiELD_SRC}/FMS/test_fms/fms/include  \
+     -I${SHiELD_SRC}/MOM6/src/framework ${BUILD_ROOT}/Build/mom6/pathnames_mom6
 
-make -j8 REPRO=Y OPENMP=Y AVX=Y NETCDF=3 Makefile libmom6.a >& Build_mom6.out
+make -j8 REPRO=Y AVX=Y NETCDF=3 Makefile libmom6.a >& Build_mom6.out
 
 ################
 #will get noise with openmp in debugmode

--- a/Build/BUILDsis2
+++ b/Build/BUILDsis2
@@ -72,10 +72,10 @@ fi
 
 mkdir -p ${BUILD_ROOT}/Build/sis2
 list_paths -l -o ${BUILD_ROOT}/Build/sis2/pathnames_sis2 \
-    ${SHiELD_SRC}/mom6/src/SIS2/config_src/dynamic_symmetric \
-    ${SHiELD_SRC}/mom6/src/SIS2/config_src/external/Icepack_interfaces \
-    ${SHiELD_SRC}/mom6/src/SIS2/src \
-    ${SHiELD_SRC}/mom6/src/icebergs/src \
+    ${SHiELD_SRC}/SIS2/config_src/dynamic_symmetric \
+    ${SHiELD_SRC}/SIS2/config_src/external/Icepack_interfaces \
+    ${SHiELD_SRC}/SIS2/src \
+    ${SHiELD_SRC}/icebergs/src \
     ${SHiELD_SRC}/ice_param 
 
 cd ${BUILD_ROOT}/Build
@@ -86,11 +86,11 @@ mkmf -m Makefile -a ${SHiELD_SRC} -p libsis2.a -t "${BUILD_ROOT}/${TEMPLATE}" \
      -c "-DINTERNAL_FILE_NML -g -DUSE_FMS2_IO -I${NCEP_DIR}/mom6 -I${NCEP_DIR}/libFMS/${COMPILER}/${BIT}" -I${SHiELD_SRC}/FMS/axis_utils/include \
      -I${SHiELD_SRC}/FMS/diag_manager/include -I${SHiELD_SRC}/FMS/fms/include -I${SHiELD_SRC}/FMS/fms2_io/include -I${SHiELD_SRC}/FMS/horiz_interp/include \
      -I${SHiELD_SRC}/FMS/include -I${SHiELD_SRC}/FMS/mpp/include -I${SHiELD_SRC}/FMS/sat_vapor_pres/include -I${SHiELD_SRC}/FMS/string_utils/include \
-     -I${SHiELD_SRC}/FMS/test_fms/fms/include -I${SHiELD_SRC}/mom6/src/MOM6/pkg/CVMix-src/include \
-     -I${SHiELD_SRC}/mom6/src/MOM6/src/framework ${BUILD_ROOT}/Build/sis2/pathnames_sis2
+     -I${SHiELD_SRC}/FMS/test_fms/fms/include -I${SHiELD_SRC}/MOM6/pkg/CVMix-src/include \
+     -I${SHiELD_SRC}/MOM6/src/framework ${BUILD_ROOT}/Build/sis2/pathnames_sis2
 
 
-make -j8  REPRO=Y OPENMP=Y AVX=Y NETCDF=3 Makefile libsis2.a >& Build_sis2.out
+make -j8  REPRO=Y AVX=Y NETCDF=3 Makefile libsis2.a >& Build_sis2.out
 
 #
 # test and report on libsis2 build success

--- a/CHECKOUT_mom6.csh
+++ b/CHECKOUT_mom6.csh
@@ -5,51 +5,19 @@ source $MODULESHOME/init/csh
 cd ../SHiELD_SRC/
 echo `pwd`
 
+git clone -b dev/gfdl https://github.com/NOAA-GFDL/MOM6/
+git clone -b dev/gfdl https://github.com/NOAA-GFDL/SIS2/
+git clone -b dev/gfdl https://github.com/NOAA-GFDL/icebergs/
 
-
-# ---------------- component 'mom6'
-echo "Cloning https://github.com/NOAA-GFDL/ocean_BGC.git on branch/tag master"
-set git_output=`git clone -q --recursive -b master https://github.com/NOAA-GFDL/ocean_BGC.git >& /dev/stdout`
-if ( $? != 0 ) then
-     echo "$git_output" | sed 's/^/**GIT ERROR** /' > /dev/stderr
-     exit 1
+(cd icebergs && git checkout dev/gfdl)
+if ("fffb6f35" != "") then
+  echo WARNING: Checking out from a fork! Work in progress
+  (cd MOM6; git submodule update --recursive --init; git checkout fffb6f35; )
 endif
-# Additional checkout commands from XML file
+if ("fac2ec43" != "") then
+  echo WARNING: Checking out from a fork! Work in progress
+  (cd SIS2;git submodule update --recursive --init; git checkout fac2ec43; )
+endif
+popd
 
-          ( cd ocean_BGC && git checkout 2023.01 )
-          git clone -b dev/gfdl https://github.com/NOAA-GFDL/MOM6-examples.git mom6
-          pushd mom6
-          git checkout 3220014e
-          git submodule update --recursive --init src/MOM6 src/SIS2 src/icebergs
-          (cd src/icebergs && git checkout dev/gfdl)
-          if ("fffb6f35" != "") then
-            echo WARNING: Checking out from a fork! Work in progress
-            (cd src/MOM6;git checkout fffb6f35; )
-          endif
-          if ("fac2ec43" != "") then
-            echo WARNING: Checking out from a fork! Work in progress
-            (cd src/SIS2;git checkout fac2ec43; )
-          endif
-          popd
-
-          pushd mom6
-          set platform_domain = `perl -T -e "use Net::Domain(hostdomain) ; print hostdomain"`
-          if ("${platform_domain}" =~ *"MsState"* ) then
-            ln -s /work/noaa/gfdlscr/pdata/gfdl/gfdl_O/datasets/ .datasets
-          else
-            ln -s /lustre/f2/pdata/gfdl/gfdl_O/datasets/ .datasets
-          endif
-          popd
-
-          test -e mom6/.datasets
-          if ($status != 0) then
-            echo ""; echo "" ; echo "   WARNING:  .datasets link in MOM6 examples directory is invalid"; echo ""; echo ""
-          endif
-
-          git clone https://gitlab.gfdl.noaa.gov/ogrp/Gaea-stats-MOM6-examples.git
-          pushd Gaea-stats-MOM6-examples/regressions/ice_ocean_SIS2
-          foreach stat ( `find . -name "ocean.stats.*"` )
-            cp $stat ../../../mom6/ice_ocean_SIS2/$stat
-          end
-          popd
 

--- a/CHECKOUT_mom6.csh
+++ b/CHECKOUT_mom6.csh
@@ -18,6 +18,3 @@ if ("fac2ec43" != "") then
   echo WARNING: Checking out from a fork! Work in progress
   (cd SIS2;git submodule update --recursive --init; git checkout fac2ec43; )
 endif
-popd
-
-


### PR DESCRIPTION
This PR aims to clean up the ocean/ice code used for SHiEMOM by removing extra checked-out and compiled codes.
The test case with the new exec runs Ok.

