### PR TITLE
remove 32bit FMS libraries, allows mixed precision compilation, add C6 environment

### DIFF
--- a/Build/mk_scripts/MAKE_libFMS
+++ b/Build/mk_scripts/MAKE_libFMS
@@ -73,29 +73,6 @@ cppDefs="-Duse_libMPI -Duse_netCDF -Duse_LARGEFILE -DHAVE_SCHED_GETAFFINITY -DIN
 \rm -rf ${NCEPDIR}/libFMS/${COMPILER}
 
 #########################
-#---CREATE 32-BIT libFMS
-#########################
-bit="32bit"
-mkdir -p ${NCEP_DIR}/libFMS/${COMPILER}/${bit}
-pushd ${NCEP_DIR}/libFMS/${COMPILER}/${bit}
-(cd ${SHiELD_SRC} ; list_paths -o ${NCEP_DIR}/libFMS/${COMPILER}/${bit}/pathnames_fms FMS)
-mkmf -m Makefile -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "$cppDefs" \
-     -p libFMS.a ${NCEP_DIR}/libFMS/${COMPILER}/${bit}/pathnames_fms
-echo "building ${NCEP_DIR}/libFMS/${COMPILER}/32bit/libFMS.a..."
-make -j8 OPENMP=Y AVX=Y 32BIT=Y PIC=${PIC} Makefile libFMS.a >& Build_libFMS.out
-
-#
-# test and report on build success
-if [ $? -ne 0 ] ; then
-   echo " ${bit} build failed "
-   exit 1
-fi
-
-#
-# return to the root directory
-popd
-
-#########################
 #---CREATE 64-BIT libFMS
 #########################
 bit="64bit"

--- a/Build/mk_scripts/mk_make
+++ b/Build/mk_scripts/mk_make
@@ -92,7 +92,7 @@ $FC --version
 
 if [ ${CONFIG} = 'shield' ] || [ ${CONFIG} = 'shieldfull' ] ; then
   NCEPLIBS="./libfv3.a"
-  NCEPLIBS+=" ${NCEP_DIR}/libFMS/${COMPILER}/${bit}/libFMS.a"
+  NCEPLIBS+=" ${NCEP_DIR}/libFMS/${COMPILER}/64bit/libFMS.a"
   NCEPLIBS+=" ./libgfs.a"
   NCEPLIBS+=" -L${NCEP_DIR}/nceplibs/${COMPILER}/ -lbacio  -lsp_d  -lw3emc_d  -lw3nco_d"
 elif [ ${CONFIG} = 'solo'  ] ; then
@@ -101,7 +101,7 @@ elif [ ${CONFIG} = 'shiemom'  ] ; then
   NCEPLIBS="./libfv3.a"
   NCEPLIBS+=" ${NCEP_DIR}/sis2/libsis2.a"
   NCEPLIBS+=" ${NCEP_DIR}/mom6/libmom6.a"
-  NCEPLIBS+=" ${NCEP_DIR}/libFMS/${COMPILER}/${bit}/libFMS.a"
+  NCEPLIBS+=" ${NCEP_DIR}/libFMS/${COMPILER}/64bit/libFMS.a"
   NCEPLIBS+=" ./libgfs.a"
   NCEPLIBS+=" -L${NCEP_DIR}/nceplibs/${COMPILER}/ -lbacio  -lsp_d  -lw3emc_d  -lw3nco_d"
 fi
@@ -113,6 +113,6 @@ fi
 (cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y NETCDF=3 ${COMP} AVX=${AVX} ${BIT} PIC=${PIC} NCEPLIBS="${NCEPLIBS}" -f Makefile_fv3)
 
 if [ ${CONFIG} = 'shield' ] ||  [ ${CONFIG} = 'shieldfull' ] || [ ${CONFIG} = 'shiemom' ] ; then
-   (cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y NETCDF=3 ${COMP} AVX=${AVX} ${BIT} PIC=${PIC} NCEPLIBS="${NCEPLIBS}" -f Makefile_driver)
+   (cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y NETCDF=3 ${COMP} AVX=${AVX} PIC=${PIC} NCEPLIBS="${NCEPLIBS}" -f Makefile_driver)
 fi
 exit 0

--- a/Build/mk_scripts/mk_makefile
+++ b/Build/mk_scripts/mk_makefile
@@ -93,12 +93,18 @@ if [ ${CONFIG} = 'shield' ] || [ ${CONFIG} = 'shieldfull' ]  ; then
   mkmf -m Makefile_gfs -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -o "-cpp" -c "${GFS_cppDefs}" \
            -p libgfs.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_gfs
 
-  mkmf -m Makefile_fv3 -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" \
-           -o "-I${SHiELD_SRC}/FMS/include -I${NCEP_DIR}/libFMS/${COMPILER}/${BIT}" -c "${FV3_cppDefs}" \
-           -p libfv3.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3
+  if [ ${CONFIG} = 'shield' ]  ; then
+    mkmf -m Makefile_fv3 -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" \
+             -o "-I${SHiELD_SRC}/FMS/include -I${NCEP_DIR}/libFMS/${COMPILER}/64bit" -c "${FV3_cppDefs}" \
+             -p libfv3.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3
+  elif [ ${CONFIG} = 'shieldfull' ] ; then
+   mkmf -m Makefile_fv3 -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" \
+             -o "-I${SHiELD_SRC}/FMS/include -I${SHiELD_SRC}/GFDL_atmos_cubed_sphere/driver/SHiELDFULL/include -I${NCEP_DIR}/libFMS/${COMPILER}/64bit" -c "${FV3_cppDefs}" \
+             -p libfv3.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3
+  fi
 
   mkmf -m Makefile_driver -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "${FV3_cppDefs}" \
-           -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${NCEP_DIR}/libFMS/${COMPILER}/${BIT}" \
+           -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${NCEP_DIR}/libFMS/${COMPILER}/64bit" \
            ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver
 
 
@@ -107,16 +113,16 @@ elif [ ${CONFIG} = 'shiemom' ] ; then
            -p libgfs.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_gfs
 
   mkmf -m Makefile_fv3 -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" \
-           -o "-I${SHiELD_SRC}/FMS/include -I${NCEP_DIR}/libFMS/${COMPILER}/${BIT}" -c "${FV3_cppDefs}" \
+           -o "-I${SHiELD_SRC}/FMS/include -I${SHiELD_SRC}/GFDL_atmos_cubed_sphere/driver/SHiELDFULL/include -I${NCEP_DIR}/libFMS/${COMPILER}/64bit" -c "${FV3_cppDefs}" \
            -p libfv3.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3
 
   mkmf -m Makefile_driver -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "${FV3_cppDefs}" \
-           -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${NCEP_DIR}/libFMS/${COMPILER}/${BIT} -I${NCEP_DIR}/mom6 -I${NCEP_DIR}/sis2" \
+           -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${NCEP_DIR}/libFMS/${COMPILER}/64bit -I${NCEP_DIR}/mom6 -I${NCEP_DIR}/sis2" \
            ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver
 
 elif [ ${CONFIG} = 'solo' ] ; then
   mkmf -m Makefile_fv3 -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "${FV3_cppDefs}" \
-          -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${NCEP_DIR}/libFMS/${COMPILER}/${BIT}" \
+          -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${NCEP_DIR}/libFMS/${COMPILER}/64bit" \
             ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3
 fi
 

--- a/Build/mk_scripts/mk_paths
+++ b/Build/mk_scripts/mk_paths
@@ -102,16 +102,16 @@ elif [ ${CONFIG} = 'shieldfull' ] ; then
       SHiELD_physics/FV3GFS/ \
       GFDL_atmos_cubed_sphere/tools/ \
       GFDL_atmos_cubed_sphere/model/ \
-      GFDL_atmos_cubed_sphere/GFDL_tools/fv_diag_column.F90 \
+      SHiELD_physics/atmos_shared/  \
+      GFDL_atmos_cubed_sphere/driver/SHiELDFULL/atmosphere.F90 \
+      GFDL_atmos_cubed_sphere/GFDL_tools/fv_diag_column.F90
+
+  list_paths -o ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver \
       ocean_null/ \
       ice_null/ \
       ice_param/ \
-      land_null/
-
-  list_paths -o ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver \
+      land_null/ \
       atmos_drivers/SHiELDFULL/ \
-      SHiELD_physics/atmos_shared/  \
-      GFDL_atmos_cubed_sphere/driver/SHiELDFULL/atmosphere.F90 \
       FMSCoupler/full/ \
       FMSCoupler/shared/
 
@@ -128,12 +128,13 @@ elif  [ ${CONFIG} = 'shiemom' ] ; then
       SHiELD_physics/FV3GFS/ \
       GFDL_atmos_cubed_sphere/tools/ \
       GFDL_atmos_cubed_sphere/model/ \
-      GFDL_atmos_cubed_sphere/GFDL_tools/fv_diag_column.F90 \
-      land_null/
+      SHiELD_physics/atmos_shared/  \
+      GFDL_atmos_cubed_sphere/driver/SHiELDFULL/atmosphere.F90 \
+      GFDL_atmos_cubed_sphere/GFDL_tools/fv_diag_column.F90
 
   list_paths -o ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver \
+      land_null/
       atmos_drivers/SHiELDFULL/ \
-      SHiELD_physics/atmos_shared/  \
       GFDL_atmos_cubed_sphere/driver/SHiELDFULL/atmosphere.F90 \
       FMSCoupler/full/ \
       FMSCoupler/shared/

--- a/site/environment.intel.sh
+++ b/site/environment.intel.sh
@@ -27,6 +27,40 @@
 hostname=`hostname`
 
 case $hostname in
+   gaea6? | c6n* )
+      echo " gaea C6 environment "
+
+      . ${MODULESHOME}/init/sh
+      module unload PrgEnv-pgi PrgEnv-intel PrgEnv-gnu
+      module load   PrgEnv-intel
+      module rm intel-classic
+      module rm intel-oneapi
+      module rm intel
+      module rm gcc
+      module load intel-classic/2023.2.0
+      module unload cray-libsci
+      module load cray-hdf5
+      module load cray-netcdf
+      module load craype-hugepages4M
+      #module load cmake/3.23.1
+      #module load libyaml/0.2.5
+
+      # Add -DHAVE_GETTID to the FMS cppDefs
+      export FMS_CPPDEFS=-DHAVE_GETTID
+
+      # make your compiler selections here
+      export FC=ftn
+      export CC=cc
+      export CXX=CC
+      export LD=ftn
+      export TEMPLATE=site/intel.mk
+      export LAUNCHER=srun
+
+      # highest level of AVX support
+      export AVX_LEVEL=-march=core-avx2
+      echo -e ' '
+      module list
+      ;;
    gaea5? | c5n* )
       echo " gaea C5 environment "
 


### PR DESCRIPTION
This PR will remove the FMS 32bit libraries and adopt 64bit to accommodate the new full coupler changes, where FMS is only compiled in double precision.
This PR allows a mixed precision compilation of a 32-bit dycore with the all other components in 64-bit.
Also adding a C6 environment.