### PR TITLE
Unload darshan module

### DIFF
--- a/site/environment.intel.sh
+++ b/site/environment.intel.sh
@@ -32,6 +32,7 @@ case $hostname in
 
       . ${MODULESHOME}/init/sh
       module unload PrgEnv-pgi PrgEnv-intel PrgEnv-gnu
+      module unload darshan-runtime
       module load   PrgEnv-intel
       module rm intel-classic
       module rm intel-oneapi
@@ -66,6 +67,7 @@ case $hostname in
 
       . ${MODULESHOME}/init/sh
       module unload PrgEnv-pgi PrgEnv-intel PrgEnv-gnu
+      module unload darshan-runtime
       module load   PrgEnv-intel
       module rm intel-classic
       module rm intel-oneapi


### PR DESCRIPTION
This avoids compilation crashes after recent updates on C5/C6.

From HD:
"We are requesting users unload the darshan-runtime module on C5 and C6.  Darshan is a library that monitors I/O load from an application, and creates reports that can be useful to determine if I/O is a bottleneck for a job’s performance.  We have used the darshan report to investigate file system issues in the past.  On Gaea, the module darshan-runtime is added to the user’s environment by default.  When this module is loaded, the darshan library is automatically linked in to all built executables on C5 and C6.  However, we have discovered there is something incorrect in the current version of the darshan-runtime library.  For now, we suggest users unload this module prior to building executables on C5 and C6.
We have asked ORNL to remove this module from the automatically loaded list of modules.  This will happen as ORNL continues to work through the C5 post-upgrade issues."
