### PR TITLE
Automatic compile option for mom6/sis2

### DIFF
--- a/Build/BUILDmom6
+++ b/Build/BUILDmom6
@@ -28,6 +28,7 @@ set -x
 # configure your build parameters
   COMPILER="intel"
   BIT="64bit"
+  COMP=""
 #
 # parse arguments
   for arg in "$@"

--- a/Build/BUILDmom6
+++ b/Build/BUILDmom6
@@ -33,6 +33,15 @@ set -x
   for arg in "$@"
   do
       case $arg in
+        prod|repro|debug)
+          comp="${arg#*=}"
+          if [ ${arg#} = 'repro' ] ; then
+            COMP="REPRO=Y"
+          elif [ ${arg#} = 'debug' ] ; then
+            COMP="DEBUG=Y"
+          fi
+          shift # Remove COMP from processing
+          ;;
           intel|gnu)
              COMPILER="${arg#*=}"
              shift # Remove "compiler" from processing
@@ -96,7 +105,7 @@ mkmf -m Makefile -a ${SHiELD_SRC} -p libmom6.a -t "${BUILD_ROOT}/${TEMPLATE}" \
      -I${SHiELD_SRC}/FMS/string_utils/include -I${SHiELD_SRC}/FMS/test_fms/fms/include  \
      -I${SHiELD_SRC}/MOM6/src/framework ${BUILD_ROOT}/Build/mom6/pathnames_mom6
 
-make -j8 REPRO=Y AVX=Y NETCDF=3 Makefile libmom6.a >& Build_mom6.out
+make -j8 ${COMP} AVX=Y NETCDF=3 Makefile libmom6.a >& Build_mom6.out
 
 ################
 #will get noise with openmp in debugmode

--- a/Build/BUILDmom6
+++ b/Build/BUILDmom6
@@ -28,14 +28,13 @@ set -x
 # configure your build parameters
   COMPILER="intel"
   BIT="64bit"
-  COMP=""
+  COMP="" # implies PROD=Y
 #
 # parse arguments
   for arg in "$@"
   do
       case $arg in
         prod|repro|debug)
-          comp="${arg#*=}"
           if [ ${arg#} = 'repro' ] ; then
             COMP="REPRO=Y"
           elif [ ${arg#} = 'debug' ] ; then
@@ -57,7 +56,8 @@ set -x
           fi
           echo -e ' '
           echo -e "valid options are:"
-          echo -e "\t[intel(D) | gnu ] \t\t\t compiler"
+          echo -e "\t[intel(D) | gnu] \t\t\t compiler"
+          echo -e "\t[prod(D) | repro | debug] \t\t compiler option settings"
 	  echo -e "\t[32bit(D) | 64bit] \t\t\t FV3 precision option"
           echo -e "\n"
           exit

--- a/Build/BUILDsis2
+++ b/Build/BUILDsis2
@@ -28,6 +28,7 @@ set -x
 # configure your build parameters
   COMPILER="intel"
   BIT="64bit"
+  COMP=""
 #
 # parse arguments
   for arg in "$@"

--- a/Build/BUILDsis2
+++ b/Build/BUILDsis2
@@ -33,6 +33,15 @@ set -x
   for arg in "$@"
   do
       case $arg in
+        prod|repro|debug)
+          comp="${arg#*=}"
+          if [ ${arg#} = 'repro' ] ; then
+            COMP="REPRO=Y"
+          elif [ ${arg#} = 'debug' ] ; then
+            COMP="DEBUG=Y"
+          fi
+          shift # Remove COMP from processing
+          ;;
           intel|gnu)
              COMPILER="${arg#*=}"
              shift # Remove "compiler" from processing
@@ -90,7 +99,7 @@ mkmf -m Makefile -a ${SHiELD_SRC} -p libsis2.a -t "${BUILD_ROOT}/${TEMPLATE}" \
      -I${SHiELD_SRC}/MOM6/src/framework ${BUILD_ROOT}/Build/sis2/pathnames_sis2
 
 
-make -j8  REPRO=Y AVX=Y NETCDF=3 Makefile libsis2.a >& Build_sis2.out
+make -j8  ${COMP} AVX=Y NETCDF=3 Makefile libsis2.a >& Build_sis2.out
 
 #
 # test and report on libsis2 build success

--- a/Build/BUILDsis2
+++ b/Build/BUILDsis2
@@ -28,14 +28,13 @@ set -x
 # configure your build parameters
   COMPILER="intel"
   BIT="64bit"
-  COMP=""
+  COMP="" # implies PROD=Y
 #
 # parse arguments
   for arg in "$@"
   do
       case $arg in
         prod|repro|debug)
-          comp="${arg#*=}"
           if [ ${arg#} = 'repro' ] ; then
             COMP="REPRO=Y"
           elif [ ${arg#} = 'debug' ] ; then
@@ -58,6 +57,7 @@ set -x
           echo -e ' '
           echo -e "valid options are:"
           echo -e "\t[intel(D) | gnu] \t\t\t compiler"
+          echo -e "\t[prod(D) | repro | debug] \t\t compiler option settings"
 	  echo -e "\t[32bit(D) | 64bit] \t\t\t FV3 precision option"
           echo -e "\n"
           exit

--- a/Build/COMPILE
+++ b/Build/COMPILE
@@ -254,11 +254,11 @@ if [ $config = "shiemom" ] ; then
 # from lauren
   # I think mom6 needs to be built in 64bit for now?
   # I can only get it to compiler with 64bit FMS
-  ./BUILDmom6 ${compiler} ${bit}
+  ./BUILDmom6 ${comp} ${compiler} ${bit}
      echo "DONE WITH MOM6"
 
 # for sis2
-  ./BUILDsis2 ${compiler} ${bit}
+  ./BUILDsis2 ${comp} ${compiler} ${bit}
      echo "DONE WITH SIS2"
 fi
 


### PR DESCRIPTION
Update the hardcoded compile options for the MOM6 and SIS2 libraries to an automatic configuration, allowing users to specify options directly with the ./COMPILE command.