### PR TITLE
64bit mom6/sis2

### DIFF
--- a/Build/BUILDmom6
+++ b/Build/BUILDmom6
@@ -37,10 +37,6 @@ set -x
              COMPILER="${arg#*=}"
              shift # Remove "compiler" from processing
              ;;
-	  32bit|64bit)
-             BIT="${arg#*=}"
-             shift # Remove *bit from processing
-             ;;
           *)
           if [ ${arg#} != '--help' ] && [ ${arg#} != '-h' ] ; then
             echo "option "${arg#}" not found"
@@ -48,7 +44,6 @@ set -x
           echo -e ' '
           echo -e "valid options are:"
           echo -e "\t[intel(D) | gnu ] \t\t\t compiler"
-	  echo -e "\t[32bit(D) | 64bit] \t\t\t FV3 precision option"
           echo -e "\n"
           exit
           ;;

--- a/Build/BUILDsis2
+++ b/Build/BUILDsis2
@@ -37,10 +37,6 @@ set -x
              COMPILER="${arg#*=}"
              shift # Remove "compiler" from processing
              ;;
-	  32bit|64bit)
-             BIT="${arg#*=}"
-             shift # Remove *bit from processing
-             ;;
           *)
           if [ ${arg#} != '--help' ] && [ ${arg#} != '-h' ] ; then
             echo "option "${arg#}" not found"
@@ -48,7 +44,6 @@ set -x
           echo -e ' '
           echo -e "valid options are:"
           echo -e "\t[intel(D) | gnu] \t\t\t compiler"
-	  echo -e "\t[32bit(D) | 64bit] \t\t\t FV3 precision option"
           echo -e "\n"
           exit
           ;;

--- a/Build/COMPILE
+++ b/Build/COMPILE
@@ -254,11 +254,19 @@ if [ $config = "shiemom" ] ; then
 # from lauren
   # I think mom6 needs to be built in 64bit for now?
   # I can only get it to compiler with 64bit FMS
-  ./BUILDmom6 ${compiler} ${bit}
+  ./BUILDmom6 ${compiler}
+     if [ $? -ne 0 ] ; then
+        echo " MOM6 build failed"
+        exit
+     fi
      echo "DONE WITH MOM6"
 
 # for sis2
-  ./BUILDsis2 ${compiler} ${bit}
+  ./BUILDsis2 ${compiler}
+     if [ $? -ne 0 ] ; then
+        echo " SIS2 build failed"
+        exit
+     fi
      echo "DONE WITH SIS2"
 fi
 


### PR DESCRIPTION
Remove the precision compilation option for MOM6/SIS2 and strictly compile them in 64bit.
Add an exit call if compilation fails to stop the COMPILE script.