### PR TITLE
Updating to csh enviornment for compatibility with csh runscripts

### DIFF
--- a/RTS/GAEA_RTS/C3072_res.csh
+++ b/RTS/GAEA_RTS/C3072_res.csh
@@ -21,6 +21,8 @@ endif
 
 set RELEASE = "`cat ${BUILD_AREA}/../SHiELD_SRC/release`"
 
+source ${BUILD_AREA}/site/environment.${COMPILER}.csh
+
 #set hires_oro_factor = 3
 set res = 3072
 

--- a/RTS/GAEA_RTS/C384.csh
+++ b/RTS/GAEA_RTS/C384.csh
@@ -21,7 +21,7 @@ endif
 
 set RELEASE = "`cat ${BUILD_AREA}/../SHiELD_SRC/release`"
 
-source ${BUILD_AREA}/site/environment.${COMPILER}.sh
+source ${BUILD_AREA}/site/environment.${COMPILER}.csh
 
 #set hires_oro_factor = 12
 set res = 384

--- a/RTS/GAEA_RTS/C48_res.csh
+++ b/RTS/GAEA_RTS/C48_res.csh
@@ -20,7 +20,7 @@ endif
 
 set RELEASE = "`cat ${BUILD_AREA}/../SHiELD_SRC/release`"
 
-source ${BUILD_AREA}/site/environment.${COMPILER}.sh
+source ${BUILD_AREA}/site/environment.${COMPILER}.csh
 
 #set hires_oro_factor = 3
 set res = 48

--- a/RTS/GAEA_RTS/C48_test.csh
+++ b/RTS/GAEA_RTS/C48_test.csh
@@ -21,7 +21,7 @@ endif
 
 set RELEASE = "`cat ${BUILD_AREA}/../SHiELD_SRC/release`"
 
-source ${BUILD_AREA}/site/environment.${COMPILER}.sh
+source ${BUILD_AREA}/site/environment.${COMPILER}.csh
 
 #set hires_oro_factor = 3
 set res = 48

--- a/RTS/GAEA_RTS/C48n4.csh
+++ b/RTS/GAEA_RTS/C48n4.csh
@@ -19,7 +19,7 @@ endif
 
 set RELEASE = "`cat ${BUILD_AREA}/../SHiELD_SRC/release`"
 
-source ${BUILD_AREA}/site/environment.${COMPILER}.sh
+source ${BUILD_AREA}/site/environment.${COMPILER}.csh
 
 #set hires_oro_factor = 3
 set res = 48

--- a/RTS/GAEA_RTS/C768.csh
+++ b/RTS/GAEA_RTS/C768.csh
@@ -20,7 +20,7 @@ endif
 
 set RELEASE = "`cat ${BUILD_AREA}/../SHiELD_SRC/release`"
 
-source ${BUILD_AREA}/site/environment.${COMPILER}.sh
+source ${BUILD_AREA}/site/environment.${COMPILER}.csh
 
 # case specific details
 set TYPE = "nh"         # choices:  nh, hydro

--- a/RTS/GAEA_RTS/C768r15n3.csh
+++ b/RTS/GAEA_RTS/C768r15n3.csh
@@ -20,7 +20,7 @@ endif
 
 set RELEASE = "`cat ${BUILD_AREA}/../SHiELD_SRC/release`"
 
-source ${BUILD_AREA}/site/environment.${COMPILER}.sh
+source ${BUILD_AREA}/site/environment.${COMPILER}.csh
 
 # case specific details
 set TYPE = "nh"         # choices:  nh, hydro

--- a/RTS/GAEA_RTS/Regional3km.csh
+++ b/RTS/GAEA_RTS/Regional3km.csh
@@ -20,7 +20,7 @@ endif
 
 set RELEASE = "`cat ${BUILD_AREA}/../SHiELD_SRC/release`"
 
-source ${BUILD_AREA}/site/environment.${COMPILER}.sh
+source ${BUILD_AREA}/site/environment.${COMPILER}.csh
 
 #set hires_oro_factor = 12
 set res = 3072

--- a/site/environment.gnu.csh
+++ b/site/environment.gnu.csh
@@ -1,0 +1,68 @@
+#!/bin/csh
+#***********************************************************************
+#*                   GNU Lesser General Public License
+#*
+#* This file is part of the SHiELD Build System.
+#*
+#* The SHiELD Build System free software: you can redistribute it
+#* and/or modify it under the terms of the
+#* GNU Lesser General Public License as published by the
+#* Free Software Foundation, either version 3 of the License, or
+#* (at your option) any later version.
+#*
+#* The SHiELD Build System distributed in the hope that it will be
+#* useful, but WITHOUT ANYWARRANTY; without even the implied warranty
+#* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#* See the GNU General Public License for more details.
+#*
+#* You should have received a copy of the GNU Lesser General Public
+#* License along with theSHiELD Build System
+#* If not, see <http://www.gnu.org/licenses/>.
+#***********************************************************************
+#
+#  DISCLAIMER: This script is provided as-is and as such is unsupported.
+#
+
+set hostname=`hostname`
+
+switch ($hostname)
+   case gaea5?:
+   case c5n*:
+      echo " gaea C5 environment "
+      source ${MODULESHOME}/init/csh
+       module unload PrgEnv-pgi PrgEnv-intel PrgEnv-gnu
+       module rm intel-classic
+       module rm intel-oneapi
+       module rm intel
+       module load   PrgEnv-gnu
+       module rm gcc
+       module load gcc-native/13.2
+       module load cray-hdf5/1.12.2.11
+       module load cray-netcdf/4.9.0.11
+       module load craype-hugepages4M
+       module load cmake/3.23.1
+       module load libyaml/0.2.5
+
+       # Add -DHAVE_GETTID to the FMS cppDefs
+       setenv FMS_CPPDEFS "-DHAVE_GETTID"
+       # Needed with the new Environment on C5 as of 10/16/2024
+       setenv FI_VERBS_PREFER_XRC 0
+
+       # make your compiler selections here
+       setenv FC "ftn"
+       setenv CC "cc"
+       setenv CXX "CC"
+       setenv LD "ftn"
+       setenv TEMPLATE "site/gnu.mk"
+       setenv LAUNCHER "srun"
+
+       # highest level of AVX support
+       setenv AVX_LEVEL "-march native"
+
+       echo -e ' '
+       module list
+       breaksw
+   default:
+       echo " no environment available based on the hostname "
+       breaksw
+endsw

--- a/site/environment.gnu.csh
+++ b/site/environment.gnu.csh
@@ -43,21 +43,10 @@ switch ($hostname)
        module load cmake/3.23.1
        module load libyaml/0.2.5
 
-       # Add -DHAVE_GETTID to the FMS cppDefs
-       setenv FMS_CPPDEFS "-DHAVE_GETTID"
        # Needed with the new Environment on C5 as of 10/16/2024
        setenv FI_VERBS_PREFER_XRC 0
 
-       # make your compiler selections here
-       setenv FC "ftn"
-       setenv CC "cc"
-       setenv CXX "CC"
-       setenv LD "ftn"
-       setenv TEMPLATE "site/gnu.mk"
        setenv LAUNCHER "srun"
-
-       # highest level of AVX support
-       setenv AVX_LEVEL "-march native"
 
        echo -e ' '
        module list

--- a/site/environment.intel.csh
+++ b/site/environment.intel.csh
@@ -1,0 +1,108 @@
+#!/bin/csh
+#***********************************************************************
+#*                   GNU Lesser General Public License
+#*
+#* This file is part of the SHiELD Build System.
+#*
+#* The SHiELD Build System free software: you can redistribute it
+#* and/or modify it under the terms of the
+#* GNU Lesser General Public License as published by the
+#* Free Software Foundation, either version 3 of the License, or
+#* (at your option) any later version.
+#*
+#* The SHiELD Build System distributed in the hope that it will be
+#* useful, but WITHOUT ANYWARRANTY; without even the implied warranty
+#* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#* See the GNU General Public License for more details.
+#*
+#* You should have received a copy of the GNU Lesser General Public
+#* License along with theSHiELD Build System
+#* If not, see <http://www.gnu.org/licenses/>.
+#***********************************************************************
+#
+#  DISCLAIMER: This script is provided as-is and as such is unsupported.
+#
+
+
+set hostname=`hostname`
+
+switch ($hostname)
+   case gaea6?:
+   case c6n*:
+      echo " gaea C6 environment "
+
+      source ${MODULESHOME}/init/csh
+      module unload PrgEnv-pgi PrgEnv-intel PrgEnv-gnu
+      module unload darshan-runtime
+      module load   PrgEnv-intel
+      module rm intel-classic
+      module rm intel-oneapi
+      module rm intel
+      module rm gcc
+      module load intel-classic/2023.2.0
+      module unload cray-libsci
+      module load cray-hdf5
+      module load cray-netcdf
+      module load craype-hugepages4M
+      #module load cmake/3.23.1
+      #module load libyaml/0.2.5
+
+      # Add -DHAVE_GETTID to the FMS cppDefs
+      setenv FMS_CPPDEFS "-DHAVE_GETTID"
+
+      # make your compiler selections here
+      setenv FC "ftn"
+      setenv CC "cc"
+      setenv CXX "CC"
+      setenv LD "ftn"
+      setenv TEMPLATE "site/intel.mk"
+      setenv LAUNCHER "srun"
+
+      # highest level of AVX support
+      setenv AVX_LEVEL "-march core-avx2"
+      echo -e ' '
+      module list
+      breaksw
+   case gaea5?:
+   case c5n*:
+      echo " gaea C5 environment "
+
+      source ${MODULESHOME}/init/csh
+      module unload PrgEnv-pgi PrgEnv-intel PrgEnv-gnu
+      module unload darshan-runtime
+      module load   PrgEnv-intel
+      module rm intel-classic
+      module rm intel-oneapi
+      module rm intel
+      module rm gcc
+      module load intel-classic/2023.2.0
+      module unload cray-libsci
+      module load cray-hdf5/1.12.2.11
+      module load cray-netcdf/4.9.0.11
+      module load craype-hugepages4M
+      module load cmake/3.23.1
+      module load libyaml/0.2.5
+
+      # Add -DHAVE_GETTID to the FMS cppDefs
+      setenv FMS_CPPDEFS "-DHAVE_GETTID"
+      # Needed with the new Environment on C5 as of 10/16/2024
+      setenv FI_VERBS_PREFER_XRC 0
+
+      # make your compiler selections here
+      setenv FC "ftn"
+      setenv CC "cc"
+      setenv CXX "CC"
+      setenv LD "ftn"
+      setenv TEMPLATE "site/intel.mk"
+      setenv LAUNCHER "srun"
+
+      # highest level of AVX support
+      setenv AVX_LEVEL "-march core-avx2"
+      echo -e ' '
+      module list
+      breaksw
+   default:
+      echo " no environment available based on the hostname "
+      breaksw
+endsw
+

--- a/site/environment.intel.csh
+++ b/site/environment.intel.csh
@@ -47,19 +47,8 @@ switch ($hostname)
       #module load cmake/3.23.1
       #module load libyaml/0.2.5
 
-      # Add -DHAVE_GETTID to the FMS cppDefs
-      setenv FMS_CPPDEFS "-DHAVE_GETTID"
-
-      # make your compiler selections here
-      setenv FC "ftn"
-      setenv CC "cc"
-      setenv CXX "CC"
-      setenv LD "ftn"
-      setenv TEMPLATE "site/intel.mk"
       setenv LAUNCHER "srun"
 
-      # highest level of AVX support
-      setenv AVX_LEVEL "-march core-avx2"
       echo -e ' '
       module list
       breaksw
@@ -83,21 +72,11 @@ switch ($hostname)
       module load cmake/3.23.1
       module load libyaml/0.2.5
 
-      # Add -DHAVE_GETTID to the FMS cppDefs
-      setenv FMS_CPPDEFS "-DHAVE_GETTID"
       # Needed with the new Environment on C5 as of 10/16/2024
       setenv FI_VERBS_PREFER_XRC 0
 
-      # make your compiler selections here
-      setenv FC "ftn"
-      setenv CC "cc"
-      setenv CXX "CC"
-      setenv LD "ftn"
-      setenv TEMPLATE "site/intel.mk"
       setenv LAUNCHER "srun"
 
-      # highest level of AVX support
-      setenv AVX_LEVEL "-march core-avx2"
       echo -e ' '
       module list
       breaksw


### PR DESCRIPTION
**Description**

Following the C5 upgrade on 16Oct2024, I noticed that environment variables set within our current bash `environment.<compiler>.sh` files, when sourced from tcsh runscripts, were not being set.  I created csh environment files to source with csh runscripts.

Fixes # (issue)

**How Has This Been Tested?**

tested on Gaea c5

**Checklist:**

Please check all whether they apply or not
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
