### PR TITLE
Add in field_table for C48_res runscript

### DIFF
--- a/tables/field_table_6species_tke
+++ b/tables/field_table_6species_tke
@@ -1,0 +1,41 @@
+# added by FRE: sphum must be present in atmos
+# specific humidity for moist runs
+ "TRACER", "atmos_mod", "sphum"
+           "longname",     "specific humidity"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic cloud water mixing ratio
+ "TRACER", "atmos_mod", "liq_wat"
+           "longname",     "cloud water mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+ "TRACER", "atmos_mod", "rainwat"
+           "longname",     "rain mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+ "TRACER", "atmos_mod", "ice_wat"
+           "longname",     "cloud ice mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+ "TRACER", "atmos_mod", "snowwat"
+           "longname",     "snow mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+ "TRACER", "atmos_mod", "graupel"
+           "longname",     "graupel mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic ozone mixing ratio tracer
+ "TRACER", "atmos_mod", "o3mr"
+           "longname",     "ozone mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# non-prognostic cloud amount
+ "TRACER", "atmos_mod", "cld_amt"
+           "longname",     "cloud amount"
+           "units",        "1"
+       "profile_type", "fixed", "surface_value=1.e30" /
+ "TRACER", "atmos_mod", "sgs_tke"
+           "longname",    "TKE"
+           "units",     "m**2/s**2"
+       "profile_type", "fixed", "surface_value=100." /

--- a/tables/field_table_6species_tke.yaml
+++ b/tables/field_table_6species_tke.yaml
@@ -1,0 +1,59 @@
+field_table:
+- field_type: tracer
+  modlist:
+  - model_type: atmos_mod
+    varlist:
+    - variable: sphum
+      longname: specific humidity
+      units: kg/kg
+      profile_type:
+      - value: fixed
+        surface_value: 1.e30
+    - variable: liq_wat
+      longname: cloud water mixing ratio
+      units: kg/kg
+      profile_type:
+      - value: fixed
+        surface_value: 1.e30
+    - variable: rainwat
+      longname: rain mixing ratio
+      units: kg/kg
+      profile_type:
+      - value: fixed
+        surface_value: 1.e30
+    - variable: ice_wat
+      longname: cloud ice mixing ratio
+      units: kg/kg
+      profile_type:
+      - value: fixed
+        surface_value: 1.e30
+    - variable: snowwat
+      longname: snow mixing ratio
+      units: kg/kg
+      profile_type:
+      - value: fixed
+        surface_value: 1.e30
+    - variable: graupel
+      longname: graupel mixing ratio
+      units: kg/kg
+      profile_type:
+      - value: fixed
+        surface_value: 1.e30
+    - variable: o3mr
+      longname: ozone mixing ratio
+      units: kg/kg
+      profile_type:
+      - value: fixed
+        surface_value: 1.e30
+    - variable: cld_amt
+      longname: cloud amount
+      units: 1
+      profile_type:
+      - value: fixed
+        surface_value: 1.e30
+    - variable: sgs_tke
+      longname: TKE
+      units: m**2/s**2
+      profile_type:
+      - value: fixed
+        surface_value: 100.0


### PR DESCRIPTION
**Description**

The C48_res.csh runscript was modified with the public release and I forgot to include its referenced field_table.

Fixes # (issue)

**How Has This Been Tested?**

Tested on Gaea

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
