### PR TITLE
Checkout latest dev/gfdl branches for MOM6/SIS2

### DIFF
--- a/CHECKOUT_mom6.csh
+++ b/CHECKOUT_mom6.csh
@@ -9,12 +9,5 @@ git clone -b dev/gfdl https://github.com/NOAA-GFDL/MOM6/
 git clone -b dev/gfdl https://github.com/NOAA-GFDL/SIS2/
 git clone -b dev/gfdl https://github.com/NOAA-GFDL/icebergs/
 
-(cd icebergs && git checkout dev/gfdl)
-if ("fffb6f35" != "") then
-  echo WARNING: Checking out from a fork! Work in progress
-  (cd MOM6; git submodule update --recursive --init; git checkout fffb6f35; )
-endif
-if ("fac2ec43" != "") then
-  echo WARNING: Checking out from a fork! Work in progress
-  (cd SIS2;git submodule update --recursive --init; git checkout fac2ec43; )
-endif
+(cd MOM6; git submodule update --recursive --init)
+(cd SIS2; git submodule update --recursive --init)


### PR DESCRIPTION
Switching to the latest up-to-date version of the branch `dev/gfdl` for MOM6 and SIS2.
No issues seen in SHiEMOM's runs on Gaea C5/C6
