### PR TITLE
Change reference to NCEPLIBS to be more generic

### DIFF
--- a/Build/BUILDlibfms
+++ b/Build/BUILDlibfms
@@ -57,15 +57,15 @@
 
 #
 # set up some default variables if not called from COMPILE
-# NCEP_DIR is set if this script is called from the COMPILE script
+# LIBS_DIR is set if this script is called from the COMPILE script
 # EXTERNAL_LIBS is set if using external location for storage of libFMS
-if [ -z ${NCEP_DIR} ] ; then
+if [ -z ${LIBS_DIR} ] ; then
    export BUILD_ROOT=${PWD%/*}
    export SHiELD_SRC=${PWD%/*/*}/SHiELD_SRC/
    export PATH="${BUILD_ROOT}/mkmf/bin:${BUILD_ROOT}/Build/mk_scripts:${PATH}"
-   export NCEP_DIR=${BUILD_ROOT}/Build
+   export LIBS_DIR=${BUILD_ROOT}/Build
    if [ ! -z ${EXTERNAL_LIBS} ] ; then
-      export NCEP_DIR=${EXTERNAL_LIBS}
+      export LIBS_DIR=${EXTERNAL_LIBS}
    fi
   # load the proper environment for your machine
    . ${BUILD_ROOT}/site/environment.${compiler}.sh
@@ -73,12 +73,12 @@ fi
 
 #
 # build FMS library
-echo " building ${NCEP_DIR}/libFMS/${compiler}"
+echo " building ${LIBS_DIR}/libFMS/${compiler}"
 MAKE_libFMS ${compiler} ${pic} >> build_libFMS_${compiler}.out 2>&1   # build 32bit and 64bit versions of libFMS
 #
 # test and report on libFMS build success
 if [ $? -ne 0 ] ; then
-  echo ">>> ${NCEPDIR}/libFMS/${compiler} build failed"
+  echo ">>> ${LIBS_DIR}/libFMS/${compiler} build failed"
   exit 1
 fi
 echo " libFMS build successful"

--- a/Build/BUILDmom6
+++ b/Build/BUILDmom6
@@ -67,9 +67,9 @@ if [ -z ${BUILD_ROOT} ] ; then
    export BUILD_ROOT=${PWD%/*}
    export SHiELD_SRC=${PWD%/*/*}/SHiELD_SRC/
    export PATH="${BUILD_ROOT}/mkmf/bin:${BUILD_ROOT}/Build/mk_scripts:${PATH}"
-   export NCEP_DIR=${BUILD_ROOT}/Build
+   export LIBS_DIR=${BUILD_ROOT}/Build
    if [ ! -z ${EXTERNAL_LIBS} ] ; then
-      export NCEP_DIR=${EXTERNAL_LIBS}
+      export LIBS_DIR=${EXTERNAL_LIBS}
    fi
    # load the proper environment for your machine
    . ${BUILD_ROOT}/site/environment.${COMPILER}.sh
@@ -77,8 +77,8 @@ fi
 
 
 
-mkdir -p ${BUILD_ROOT}/Build/mom6
-list_paths -l -o ${BUILD_ROOT}/Build/mom6/pathnames_mom6 \
+mkdir -p ${LIBS_DIR}/mom6/${COMPILER}
+list_paths -l -o ${LIBS_DIR}/mom6/${COMPILER}/pathnames_mom6 \
     ${SHiELD_SRC}/MOM6/config_src/memory/dynamic_nonsymmetric \
     ${SHiELD_SRC}/MOM6/config_src/drivers/FMS_cap \
     ${SHiELD_SRC}/MOM6/src/*/ \
@@ -90,16 +90,16 @@ list_paths -l -o ${BUILD_ROOT}/Build/mom6/pathnames_mom6 \
     ${SHiELD_SRC}/MOM6/config_src/external/GFDL_ocean_BGC \
     ${SHiELD_SRC}/MOM6/pkg/GSW-Fortran/*/ \
     ${SHiELD_SRC}/MOM6/config_src/infra/FMS2
-cd ${BUILD_ROOT}/Build
+cd ${LIBS_DIR}
 
-pushd mom6
+pushd mom6/${COMPILER}
 
 mkmf -m Makefile -a ${SHiELD_SRC} -p libmom6.a -t "${BUILD_ROOT}/${TEMPLATE}" \
-     -c "-DINTERNAL_FILE_NML -g -DMAX_FIELDS_=100 -DNOT_SET_AFFINITY -D_USE_MOM6_DIAG -D_USE_GENERIC_TRACER -DUSE_PRECISION=2 -I${NCEP_DIR}/libFMS/${COMPILER}/${BIT}" \
+     -c "-DINTERNAL_FILE_NML -g -DMAX_FIELDS_=100 -DNOT_SET_AFFINITY -D_USE_MOM6_DIAG -D_USE_GENERIC_TRACER -DUSE_PRECISION=2 -I${LIBS_DIR}/libFMS/${COMPILER}/${BIT}" \
      -I${SHiELD_SRC}/FMS/axis_utils/include -I${SHiELD_SRC}/FMS/diag_manager/include -I${SHiELD_SRC}/FMS/fms/include -I${SHiELD_SRC}/FMS/fms2_io/include \
      -I${SHiELD_SRC}/FMS/horiz_interp/include -I${SHiELD_SRC}/FMS/include -I${SHiELD_SRC}/FMS/mpp/include -I${SHiELD_SRC}/FMS/sat_vapor_pres/include \
      -I${SHiELD_SRC}/FMS/string_utils/include -I${SHiELD_SRC}/FMS/test_fms/fms/include  \
-     -I${SHiELD_SRC}/MOM6/src/framework ${BUILD_ROOT}/Build/mom6/pathnames_mom6
+     -I${SHiELD_SRC}/MOM6/src/framework ${LIBS_DIR}/mom6/${COMPILER}/pathnames_mom6
 
 make -j8 ${COMP} AVX=Y NETCDF=3 Makefile libmom6.a >& Build_mom6.out
 
@@ -109,7 +109,7 @@ make -j8 ${COMP} AVX=Y NETCDF=3 Makefile libmom6.a >& Build_mom6.out
 
 # test and report on libFMS build success
 if [ $? -ne 0 ] ; then
-  echo ">>> ${BUILD_ROOT}/Build/mom6 build failed"
+  echo ">>> ${LIBS_DIR}/mom6/${COMPILER} build failed"
   exit 1
 fi
 echo " libmom6 build successful"

--- a/Build/BUILDnceplibs
+++ b/Build/BUILDnceplibs
@@ -60,19 +60,19 @@ version_w3nco="v2.4.1"
   done
 
 # set up some default variables if not called from COMPILE
-# NCEP_DIR is set if this script is called from the COMPILE script
+# LIBS_DIR is set if this script is called from the COMPILE script
 # EXTERNAL_LIBS is set if using external location for storage of nceplibs
-if [ -z ${NCEP_DIR} ] ; then
+if [ -z ${LIBS_DIR} ] ; then
    BUILD_ROOT=${PWD%/*}
-   NCEP_DIR=${BUILD_ROOT}/Build
+   LIBS_DIR=${BUILD_ROOT}/Build
    if [ ! -z ${EXTERNAL_LIBS} ] ; then
-   NCEP_DIR=${EXTERNAL_LIBS}
+   LIBS_DIR=${EXTERNAL_LIBS}
    fi
    # load the proper environment for your machine
    . ${BUILD_ROOT}/site/environment.${compiler}.sh
 fi
 
-nceplibs_dir=${NCEP_DIR}/nceplibs/${compiler}
+nceplibs_dir=${LIBS_DIR}/nceplibs/${compiler}
 \rm -rf $nceplibs_dir
 mkdir -p $nceplibs_dir
 cd $nceplibs_dir

--- a/Build/BUILDsis2
+++ b/Build/BUILDsis2
@@ -66,33 +66,33 @@ if [ -z ${BUILD_ROOT} ] ; then
    export BUILD_ROOT=${PWD%/*}
    export SHiELD_SRC=${PWD%/*/*}/SHiELD_SRC/
    export PATH="${BUILD_ROOT}/mkmf/bin:${BUILD_ROOT}/Build/mk_scripts:${PATH}"
-   export NCEP_DIR=${BUILD_ROOT}/Build
+   export LIBS_DIR=${BUILD_ROOT}/Build
    if [ ! -z ${EXTERNAL_LIBS} ] ; then
-      export NCEP_DIR=${EXTERNAL_LIBS}
+      export LIBS_DIR=${EXTERNAL_LIBS}
    fi
    # load the proper environment for your machine
    . ${BUILD_ROOT}/site/environment.${COMPILER}.sh
 fi
 
 
-mkdir -p ${BUILD_ROOT}/Build/sis2
-list_paths -l -o ${BUILD_ROOT}/Build/sis2/pathnames_sis2 \
+mkdir -p ${LIBS_DIR}/sis2/${COMPILER}
+list_paths -l -o ${LIBS_DIR}/sis2/${COMPILER}/pathnames_sis2 \
     ${SHiELD_SRC}/SIS2/config_src/dynamic_symmetric \
     ${SHiELD_SRC}/SIS2/config_src/external/Icepack_interfaces \
     ${SHiELD_SRC}/SIS2/src \
     ${SHiELD_SRC}/icebergs/src \
     ${SHiELD_SRC}/ice_param 
 
-cd ${BUILD_ROOT}/Build
+cd ${LIBS_DIR}
 
-pushd sis2
+pushd sis2/${COMPILER}
 
 mkmf -m Makefile -a ${SHiELD_SRC} -p libsis2.a -t "${BUILD_ROOT}/${TEMPLATE}" \
-     -c "-DINTERNAL_FILE_NML -g -DUSE_FMS2_IO -I${NCEP_DIR}/mom6 -I${NCEP_DIR}/libFMS/${COMPILER}/${BIT}" -I${SHiELD_SRC}/FMS/axis_utils/include \
+     -c "-DINTERNAL_FILE_NML -g -DUSE_FMS2_IO -I${LIBS_DIR}/mom6/${COMPILER} -I${LIBS_DIR}/libFMS/${COMPILER}/${BIT}" -I${SHiELD_SRC}/FMS/axis_utils/include \
      -I${SHiELD_SRC}/FMS/diag_manager/include -I${SHiELD_SRC}/FMS/fms/include -I${SHiELD_SRC}/FMS/fms2_io/include -I${SHiELD_SRC}/FMS/horiz_interp/include \
      -I${SHiELD_SRC}/FMS/include -I${SHiELD_SRC}/FMS/mpp/include -I${SHiELD_SRC}/FMS/sat_vapor_pres/include -I${SHiELD_SRC}/FMS/string_utils/include \
      -I${SHiELD_SRC}/FMS/test_fms/fms/include -I${SHiELD_SRC}/MOM6/pkg/CVMix-src/include \
-     -I${SHiELD_SRC}/MOM6/src/framework ${BUILD_ROOT}/Build/sis2/pathnames_sis2
+     -I${SHiELD_SRC}/MOM6/src/framework ${LIBS_DIR}/sis2/${COMPILER}/pathnames_sis2
 
 
 make -j8  ${COMP} AVX=Y NETCDF=3 Makefile libsis2.a >& Build_sis2.out
@@ -100,7 +100,7 @@ make -j8  ${COMP} AVX=Y NETCDF=3 Makefile libsis2.a >& Build_sis2.out
 #
 # test and report on libsis2 build success
 if [ $? -ne 0 ] ; then
-  echo ">>> ${BUILD_ROOT}/Build/sis2 build failed"
+  echo ">>> ${LIBS_DIR}/sis2/${COMPILER} build failed"
   exit 1
 fi
 echo " libsis2 build successful"

--- a/Build/COMPILE
+++ b/Build/COMPILE
@@ -150,7 +150,7 @@ fi
 export BUILD_ROOT=${PWD%/*}
 export SHiELD_SRC=${PWD%/*/*}/SHiELD_SRC/
 export PATH="${BUILD_ROOT}/mkmf/bin:${BUILD_ROOT}/Build/mk_scripts:${PATH}"
-export NCEP_DIR=${BUILD_ROOT}/Build
+export LIBS_DIR=${BUILD_ROOT}/Build
 
 #
 # load the proper environment for your machine
@@ -197,8 +197,8 @@ fi
      \rm -rf libFMS/${compiler}/*
      \rm -rf exec/${config}_${hydro}.${comp}.${bit}.${compiler}/*
      \rm -rf nceplibs/${compiler}/*
-     \rm -rf mom6/*
-     \rm -rf sis2/*
+     \rm -rf mom6/${compiler}/*
+     \rm -rf sis2/${compiler}/*
   elif [ ${clean} = "clean" ] ; then
      echo " cleaning build directory in 2 seconds"
      sleep 2
@@ -206,39 +206,40 @@ fi
   elif [ ${clean} = "cleanmom" ] ; then
      echo " cleaning build directory in 2 seconds"
      sleep 2
-     \rm -rf mom6/*
-     \rm -rf sis2/*
+     \rm -rf mom6/${compiler}/*
+     \rm -rf sis2/${compiler}/*
+     \rm -rf exec/${config}_${hydro}.${comp}.${bit}.${compiler}/*
   fi
 
 # If EXTERNAL_LIBS is set, then the program will use the path defined by
 #    EXTERNAL_LIBS as the location of nceplibs and libFMS
   if [ ! -z ${EXTERNAL_LIBS} ] ; then
     echo " External Libraries are being used: ${EXTERNAL_LIBS}"
-    export NCEP_DIR=${EXTERNAL_LIBS}
+    export LIBS_DIR=${EXTERNAL_LIBS}
   fi
 #
 # check to make sure libFMS exists
-  if [ -d ${NCEP_DIR}/libFMS/${compiler} ] && [ -e ${NCEP_DIR}/libFMS/${compiler}/32bit/libFMS.a ] && \
-     [ -e ${NCEP_DIR}/libFMS/${compiler}/64bit/libFMS.a ] ; then
-     echo " pre-built ${NCEP_DIR}/libFMS/${compiler} exists"
+  if [ -d ${LIBS_DIR}/libFMS/${compiler} ] && [ -e ${LIBS_DIR}/libFMS/${compiler}/32bit/libFMS.a ] && \
+     [ -e ${LIBS_DIR}/libFMS/${compiler}/64bit/libFMS.a ] ; then
+     echo " pre-built ${LIBS_DIR}/libFMS/${compiler} exists"
   else
-     echo " ${NCEP_DIR}/libFMS/${compiler} does not exist"
+     echo " ${LIBS_DIR}/libFMS/${compiler} does not exist"
      ./BUILDlibfms ${compiler} ${pic}
      if [ $? -ne 0 ] ; then
-        echo ">>> ${NCEP_DIR}/Libfms/${compiler} build failed"
+        echo ">>> ${LIBS_DIR}/Libfms/${compiler} build failed"
         exit 2
      fi
   fi
 # check to make sure nceplibs exists
-  if [ -d ${NCEP_DIR}/nceplibs/${compiler} ] && [ -e ${NCEP_DIR}/nceplibs/${compiler}/libbacio.a ] && \
-     [ -e ${NCEP_DIR}/nceplibs/${compiler}/libsp_d.a ] && [ -e ${NCEP_DIR}/nceplibs/${compiler}/libw3emc_d.a ] && \
-     [ -e ${NCEP_DIR}/nceplibs/${compiler}/libw3nco_d.a ] ; then
-     echo " pre-built ${NCEP_DIR}/nceplibs/${compiler} exists"
+  if [ -d ${LIBS_DIR}/nceplibs/${compiler} ] && [ -e ${LIBS_DIR}/nceplibs/${compiler}/libbacio.a ] && \
+     [ -e ${LIBS_DIR}/nceplibs/${compiler}/libsp_d.a ] && [ -e ${LIBS_DIR}/nceplibs/${compiler}/libw3emc_d.a ] && \
+     [ -e ${LIBS_DIR}/nceplibs/${compiler}/libw3nco_d.a ] ; then
+     echo " pre-built ${LIBS_DIR}/nceplibs/${compiler} exists"
   else
-     echo " ${NCEP_DIR}/nceplibs/${compiler} does not exist"
+     echo " ${LIBS_DIR}/nceplibs/${compiler} does not exist"
      ./BUILDnceplibs ${compiler} ${pic}
      if [ $? -ne 0 ] ; then
-        echo ">>> ${NCEP_DIR}/ncepdir/${compiler} build failed"
+        echo ">>> ${LIBS_DIR}/ncepdir/${compiler} build failed"
         exit 3
      fi
   fi
@@ -247,20 +248,30 @@ if [ $config = "shiemom" ] ; then
 # from lauren
   # I think mom6 needs to be built in 64bit for now?
   # I can only get it to compiler with 64bit FMS
-  ./BUILDmom6 ${comp} ${compiler}
+  if [ -d ${LIBS_DIR}/mom6/${compiler} ] && [ -e ${LIBS_DIR}/mom6/${compiler}/libmom6.a ] ; then
+     echo " pre-built ${LIBS_DIR}/mom6/${compiler} exists"
+  else
+     echo " ${LIBS_DIR}/mom6/${compiler} does not exist"
+     ./BUILDmom6 ${comp} ${compiler}
      if [ $? -ne 0 ] ; then
         echo " MOM6 build failed"
         exit
      fi
      echo "DONE WITH MOM6"
+  fi
 
 # for sis2
-  ./BUILDsis2 ${comp} ${compiler}
+  if [ -d ${LIBS_DIR}/sis2/${compiler} ] && [ -e ${LIBS_DIR}/sis2/${compiler}/libsis2.a ] ; then
+     echo " pre-built ${LIBS_DIR}/sis2/${compiler} exists"
+  else
+     echo " ${LIBS_DIR}/sis2/${compiler} does not exist"
+     ./BUILDsis2 ${comp} ${compiler}
      if [ $? -ne 0 ] ; then
         echo " SIS2 build failed"
         exit
      fi
      echo "DONE WITH SIS2"
+  fi
 fi
 
 #

--- a/Build/mk_scripts/MAKE_libFMS
+++ b/Build/mk_scripts/MAKE_libFMS
@@ -68,12 +68,12 @@ cppDefs="-Duse_libMPI -Duse_netCDF -Duse_LARGEFILE -DHAVE_SCHED_GETAFFINITY -DIN
 #---CREATE 32-BIT libFMS
 #########################
 bit="32bit"
-mkdir -p ${NCEP_DIR}/libFMS/${COMPILER}/${bit}
-pushd ${NCEP_DIR}/libFMS/${COMPILER}/${bit}
-(cd ${SHiELD_SRC} ; list_paths -o ${NCEP_DIR}/libFMS/${COMPILER}/${bit}/pathnames_fms FMS)
+mkdir -p ${LIBS_DIR}/libFMS/${COMPILER}/${bit}
+pushd ${LIBS_DIR}/libFMS/${COMPILER}/${bit}
+(cd ${SHiELD_SRC} ; list_paths -o ${LIBS_DIR}/libFMS/${COMPILER}/${bit}/pathnames_fms FMS)
 mkmf -m Makefile -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "$cppDefs" \
-     -p libFMS.a ${NCEP_DIR}/libFMS/${COMPILER}/${bit}/pathnames_fms
-echo "building ${NCEP_DIR}/libFMS/${COMPILER}/32bit/libFMS.a..."
+     -p libFMS.a ${LIBS_DIR}/libFMS/${COMPILER}/${bit}/pathnames_fms
+echo "building ${LIBS_DIR}/libFMS/${COMPILER}/32bit/libFMS.a..."
 make -j8 OPENMP=Y AVX=Y 32BIT=Y PIC=${PIC} Makefile libFMS.a >& Build_libFMS.out
 
 #
@@ -91,12 +91,12 @@ popd
 #---CREATE 64-BIT libFMS
 #########################
 bit="64bit"
-mkdir -p ${NCEP_DIR}/libFMS/${COMPILER}/${bit}
-pushd ${NCEP_DIR}/libFMS/${COMPILER}/${bit}
-(cd ${SHiELD_SRC} ; list_paths -o ${NCEP_DIR}/libFMS/${COMPILER}/${bit}/pathnames_fms FMS)
+mkdir -p ${LIBS_DIR}/libFMS/${COMPILER}/${bit}
+pushd ${LIBS_DIR}/libFMS/${COMPILER}/${bit}
+(cd ${SHiELD_SRC} ; list_paths -o ${LIBS_DIR}/libFMS/${COMPILER}/${bit}/pathnames_fms FMS)
 mkmf -m Makefile -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "$cppDefs" \
-     -p libFMS.a ${NCEP_DIR}/libFMS/${COMPILER}/${bit}/pathnames_fms
-echo "building ${NCEP_DIR}/libFMS/${COMPILER}/64bit/libFMS.a..."
+     -p libFMS.a ${LIBS_DIR}/libFMS/${COMPILER}/${bit}/pathnames_fms
+echo "building ${LIBS_DIR}/libFMS/${COMPILER}/64bit/libFMS.a..."
 make -j8 OPENMP=Y AVX=Y PIC=${PIC} Makefile libFMS.a >& Build_libFMS.out
 
 #

--- a/Build/mk_scripts/mk_make
+++ b/Build/mk_scripts/mk_make
@@ -91,23 +91,23 @@ module list
 $FC --version
 if [ ${CONFIG} = 'shield' ] ; then
   NCEPLIBS="./libfv3.a"
-  NCEPLIBS+=" ${NCEP_DIR}/libFMS/${COMPILER}/${bit}/libFMS.a"
+  NCEPLIBS+=" ${LIBS_DIR}/libFMS/${COMPILER}/${bit}/libFMS.a"
   NCEPLIBS+=" ./libgfs.a"
-  NCEPLIBS+=" -L${NCEP_DIR}/nceplibs/${COMPILER}/ -lbacio  -lsp_d  -lw3emc_d  -lw3nco_d"
+  NCEPLIBS+=" -L${LIBS_DIR}/nceplibs/${COMPILER}/ -lbacio  -lsp_d  -lw3emc_d  -lw3nco_d"
 elif [ ${CONFIG} = 'shieldfull' ] ; then
   NCEPLIBS="./libfv3.a"
-  NCEPLIBS+=" ${NCEP_DIR}/libFMS/${COMPILER}/64bit/libFMS.a"
+  NCEPLIBS+=" ${LIBS_DIR}/libFMS/${COMPILER}/64bit/libFMS.a"
   NCEPLIBS+=" ./libgfs.a"
-  NCEPLIBS+=" -L${NCEP_DIR}/nceplibs/${COMPILER}/ -lbacio  -lsp_d  -lw3emc_d  -lw3nco_d"
+  NCEPLIBS+=" -L${LIBS_DIR}/nceplibs/${COMPILER}/ -lbacio  -lsp_d  -lw3emc_d  -lw3nco_d"
 elif [ ${CONFIG} = 'solo'  ] ; then
-  NCEPLIBS=${NCEP_DIR}/libFMS/${COMPILER}/${bit}/libFMS.a
+  NCEPLIBS=${LIBS_DIR}/libFMS/${COMPILER}/${bit}/libFMS.a
 elif [ ${CONFIG} = 'shiemom'  ] ; then
   NCEPLIBS="./libfv3.a"
-  NCEPLIBS+=" ${NCEP_DIR}/sis2/libsis2.a"
-  NCEPLIBS+=" ${NCEP_DIR}/mom6/libmom6.a"
-  NCEPLIBS+=" ${NCEP_DIR}/libFMS/${COMPILER}/64bit/libFMS.a"
+  NCEPLIBS+=" ${LIBS_DIR}/sis2/${COMPILER}/libsis2.a"
+  NCEPLIBS+=" ${LIBS_DIR}/mom6/${COMPILER}/libmom6.a"
+  NCEPLIBS+=" ${LIBS_DIR}/libFMS/${COMPILER}/64bit/libFMS.a"
   NCEPLIBS+=" ./libgfs.a"
-  NCEPLIBS+=" -L${NCEP_DIR}/nceplibs/${COMPILER}/ -lbacio  -lsp_d  -lw3emc_d  -lw3nco_d"
+  NCEPLIBS+=" -L${LIBS_DIR}/nceplibs/${COMPILER}/ -lbacio  -lsp_d  -lw3emc_d  -lw3nco_d"
 fi
 
 if [ ${CONFIG} = 'shield' ] ||  [ ${CONFIG} = 'shieldfull' ] || [ ${CONFIG} = 'shiemom' ]  ; then

--- a/Build/mk_scripts/mk_make
+++ b/Build/mk_scripts/mk_make
@@ -90,35 +90,35 @@ module list
 
 $FC --version
 if [ ${CONFIG} = 'shield' ] ; then
-  NCEPLIBS="./libfv3.a"
-  NCEPLIBS+=" ${LIBS_DIR}/libFMS/${COMPILER}/${bit}/libFMS.a"
-  NCEPLIBS+=" ./libgfs.a"
-  NCEPLIBS+=" -L${LIBS_DIR}/nceplibs/${COMPILER}/ -lbacio  -lsp_d  -lw3emc_d  -lw3nco_d"
+  EXTERNALLIBS="./libfv3.a"
+  EXTERNALLIBS+=" ${LIBS_DIR}/libFMS/${COMPILER}/${bit}/libFMS.a"
+  EXTERNALLIBS+=" ./libgfs.a"
+  EXTERNALLIBS+=" -L${LIBS_DIR}/nceplibs/${COMPILER}/ -lbacio  -lsp_d  -lw3emc_d  -lw3nco_d"
 elif [ ${CONFIG} = 'shieldfull' ] ; then
-  NCEPLIBS="./libfv3.a"
-  NCEPLIBS+=" ${LIBS_DIR}/libFMS/${COMPILER}/64bit/libFMS.a"
-  NCEPLIBS+=" ./libgfs.a"
-  NCEPLIBS+=" -L${LIBS_DIR}/nceplibs/${COMPILER}/ -lbacio  -lsp_d  -lw3emc_d  -lw3nco_d"
+  EXTERNALLIBS="./libfv3.a"
+  EXTERNALLIBS+=" ${LIBS_DIR}/libFMS/${COMPILER}/64bit/libFMS.a"
+  EXTERNALLIBS+=" ./libgfs.a"
+  EXTERNALLIBS+=" -L${LIBS_DIR}/nceplibs/${COMPILER}/ -lbacio  -lsp_d  -lw3emc_d  -lw3nco_d"
 elif [ ${CONFIG} = 'solo'  ] ; then
-  NCEPLIBS=${LIBS_DIR}/libFMS/${COMPILER}/${bit}/libFMS.a
+  EXTERNALLIBS=${LIBS_DIR}/libFMS/${COMPILER}/${bit}/libFMS.a
 elif [ ${CONFIG} = 'shiemom'  ] ; then
-  NCEPLIBS="./libfv3.a"
-  NCEPLIBS+=" ${LIBS_DIR}/sis2/${COMPILER}/libsis2.a"
-  NCEPLIBS+=" ${LIBS_DIR}/mom6/${COMPILER}/libmom6.a"
-  NCEPLIBS+=" ${LIBS_DIR}/libFMS/${COMPILER}/64bit/libFMS.a"
-  NCEPLIBS+=" ./libgfs.a"
-  NCEPLIBS+=" -L${LIBS_DIR}/nceplibs/${COMPILER}/ -lbacio  -lsp_d  -lw3emc_d  -lw3nco_d"
+  EXTERNALLIBS="./libfv3.a"
+  EXTERNALLIBS+=" ${LIBS_DIR}/sis2/${COMPILER}/libsis2.a"
+  EXTERNALLIBS+=" ${LIBS_DIR}/mom6/${COMPILER}/libmom6.a"
+  EXTERNALLIBS+=" ${LIBS_DIR}/libFMS/${COMPILER}/64bit/libFMS.a"
+  EXTERNALLIBS+=" ./libgfs.a"
+  EXTERNALLIBS+=" -L${LIBS_DIR}/nceplibs/${COMPILER}/ -lbacio  -lsp_d  -lw3emc_d  -lw3nco_d"
 fi
 
 if [ ${CONFIG} = 'shield' ] ||  [ ${CONFIG} = 'shieldfull' ] || [ ${CONFIG} = 'shiemom' ]  ; then
   (cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y ${COMP} AVX=${AVX} PIC=${PIC} -f Makefile_gfs)
 fi
 
-(cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y NETCDF=3 ${COMP} AVX=${AVX} ${BIT} PIC=${PIC} NCEPLIBS="${NCEPLIBS}" -f Makefile_fv3)
+(cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y NETCDF=3 ${COMP} AVX=${AVX} ${BIT} PIC=${PIC} EXTERNALLIBS="${EXTERNALLIBS}" -f Makefile_fv3)
 
 if   [ ${CONFIG} = 'shieldfull' ] || [ ${CONFIG} = 'shiemom' ] ; then
-   (cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y NETCDF=3 ${COMP} AVX=${AVX} PIC=${PIC} NCEPLIBS="${NCEPLIBS}" -f Makefile_driver)
+   (cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y NETCDF=3 ${COMP} AVX=${AVX} PIC=${PIC} EXTERNALLIBS="${EXTERNALLIBS}" -f Makefile_driver)
 elif [ ${CONFIG} = 'shield' ] ; then
-   (cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y NETCDF=3 ${COMP} AVX=${AVX} ${BIT} PIC=${PIC} NCEPLIBS="${NCEPLIBS}" -f Makefile_driver)
+   (cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y NETCDF=3 ${COMP} AVX=${AVX} ${BIT} PIC=${PIC} EXTERNALLIBS="${EXTERNALLIBS}" -f Makefile_driver)
 fi
 exit 0

--- a/Build/mk_scripts/mk_makefile
+++ b/Build/mk_scripts/mk_makefile
@@ -95,17 +95,17 @@ if [ ${CONFIG} = 'shield' ] || [ ${CONFIG} = 'shieldfull' ]  ; then
 
   if [ ${CONFIG} = 'shield' ]  ; then
     mkmf -m Makefile_fv3 -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" \
-             -o "-I${SHiELD_SRC}/FMS/include -I${NCEP_DIR}/libFMS/${COMPILER}/${BIT}" -c "${FV3_cppDefs}" \
+             -o "-I${SHiELD_SRC}/FMS/include -I${LIBS_DIR}/libFMS/${COMPILER}/${BIT}" -c "${FV3_cppDefs}" \
              -p libfv3.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3
     mkmf -m Makefile_driver -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "${FV3_cppDefs}" \
-             -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${NCEP_DIR}/libFMS/${COMPILER}/${BIT}" \
+             -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${LIBS_DIR}/libFMS/${COMPILER}/${BIT}" \
              ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver
   elif [ ${CONFIG} = 'shieldfull' ] ; then
    mkmf -m Makefile_fv3 -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" \
-             -o "-I${SHiELD_SRC}/FMS/include -I${SHiELD_SRC}/GFDL_atmos_cubed_sphere/driver/SHiELDFULL/include -I${NCEP_DIR}/libFMS/${COMPILER}/64bit" -c "${FV3_cppDefs}" \
+             -o "-I${SHiELD_SRC}/FMS/include -I${SHiELD_SRC}/GFDL_atmos_cubed_sphere/driver/SHiELDFULL/include -I${LIBS_DIR}/libFMS/${COMPILER}/64bit" -c "${FV3_cppDefs}" \
              -p libfv3.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3
    mkmf -m Makefile_driver -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "${FV3_cppDefs}" \
-             -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${NCEP_DIR}/libFMS/${COMPILER}/64bit" \
+             -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${LIBS_DIR}/libFMS/${COMPILER}/64bit" \
              ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver
   fi
 
@@ -115,16 +115,16 @@ elif [ ${CONFIG} = 'shiemom' ] ; then
            -p libgfs.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_gfs
 
   mkmf -m Makefile_fv3 -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" \
-           -o "-I${SHiELD_SRC}/FMS/include -I${SHiELD_SRC}/GFDL_atmos_cubed_sphere/driver/SHiELDFULL/include -I${NCEP_DIR}/libFMS/${COMPILER}/64bit" -c "${FV3_cppDefs}" \
+           -o "-I${SHiELD_SRC}/FMS/include -I${SHiELD_SRC}/GFDL_atmos_cubed_sphere/driver/SHiELDFULL/include -I${LIBS_DIR}/libFMS/${COMPILER}/64bit" -c "${FV3_cppDefs}" \
            -p libfv3.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3
 
   mkmf -m Makefile_driver -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "${FV3_cppDefs}" \
-           -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${NCEP_DIR}/libFMS/${COMPILER}/64bit -I${NCEP_DIR}/mom6 -I${NCEP_DIR}/sis2" \
+           -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${LIBS_DIR}/libFMS/${COMPILER}/64bit -I${LIBS_DIR}/mom6/${COMPILER} -I${LIBS_DIR}/sis2/${COMPILER}" \
            ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver
 
 elif [ ${CONFIG} = 'solo' ] ; then
   mkmf -m Makefile_fv3 -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "${FV3_cppDefs}" \
-          -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${NCEP_DIR}/libFMS/${COMPILER}/${BIT}" \
+          -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${LIBS_DIR}/libFMS/${COMPILER}/${BIT}" \
             ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3
 fi
 

--- a/Build/mk_scripts/mk_makefile
+++ b/Build/mk_scripts/mk_makefile
@@ -131,11 +131,11 @@ fi
 ############################
 #---ADD LIBS TO FINAL LINK
 ############################
-sed 's/LDFLAGS/NCEPLIBS) $(LDFLAGS/g' < Makefile_fv3 > OUT
+sed 's/LDFLAGS/EXTERNALLIBS) $(LDFLAGS/g' < Makefile_fv3 > OUT
 mv OUT Makefile_fv3
 
 if [ ${CONFIG} = 'shield' ] ||  [ ${CONFIG} = 'shieldfull' ] || [ ${CONFIG} = 'shiemom' ] ; then
-  sed 's/LDFLAGS/NCEPLIBS) $(LDFLAGS/g' < Makefile_driver > OUT
+  sed 's/LDFLAGS/EXTERNALLIBS) $(LDFLAGS/g' < Makefile_driver > OUT
   mv OUT Makefile_driver
 fi
 ############################


### PR DESCRIPTION
**Description**

SHiELD_build will build FMS, NCEPLIBS, mom6, and sis2 before building SHiELD, linking in the FMS, NCEPLIBS, mom6 and sis2 libraries.  The directory where these 4 libraries are built has been referred to as `NCEP_DIR`, and when linking to these libraries, the `-L and -l` flags were stored in an environment variable `NCEPLIBS`.  This PR would change the naming convention to be more generic.  `NCEP_DIR` becomes `LIBS_DIR` and `NCEPLIBS` becomes `EXTERNALLIBS`.  

This PR also modifies the build directory structure for mom6 and sis2 to create a unique build directory for builds with different compilers similarly to what is done with other component builds in SHiELD_build.

Fixes # (issue)

**How Has This Been Tested?**

Tested on Gaea.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
