### PR TITLE
remove old shield infra, rename shieldfull as shield

### DIFF
--- a/Build/COMPILE
+++ b/Build/COMPILE
@@ -64,13 +64,10 @@ spin()
   for arg in "$@"
   do
       case $arg in
-          shield|solo|shieldfull|shiemom)
+          shield|solo|shield|shiemom)
              config="${arg#*=}"
              if [ $config = 'solo' ] ; then
                config_name="SOLO"
-             fi
-             if [ $config = 'shieldfull' ] ; then
-               config_name="SHiELDFULL"
              fi
              if [ $config = 'shiemom' ] ; then
                config_name="SHiEMOM"
@@ -121,7 +118,7 @@ spin()
           fi
           echo -e ' '
           echo -e "valid options are:"
-          echo -e "\t[shield(D) | shieldfull | solo | shiemom] \t\t\t configuration"
+          echo -e "\t[shield(D)  | solo | shiemom] \t\t\t configuration"
           echo -e "\t[nh(D) | hydro | sw] \t\t\t executable configuration"
           echo -e "\t[prod(D) | repro | debug] \t\t compiler option settings"
           echo -e "\t[32bit(D) | 64bit] \t\t\t FV3 precision option"

--- a/Build/mk_scripts/mk_make
+++ b/Build/mk_scripts/mk_make
@@ -41,7 +41,7 @@ pic="nopic"
 for arg in "$@"
 do
     case $arg in
-        shield|solo|shieldfull|shiemom)
+        shield|solo|shiemom)
           CONFIG="${arg#*=}"
           shift # Remove CONFIG from processing
           ;;
@@ -91,11 +91,6 @@ module list
 $FC --version
 if [ ${CONFIG} = 'shield' ] ; then
   EXTERNALLIBS="./libfv3.a"
-  EXTERNALLIBS+=" ${LIBS_DIR}/libFMS/${COMPILER}/${bit}/libFMS.a"
-  EXTERNALLIBS+=" ./libgfs.a"
-  EXTERNALLIBS+=" -L${LIBS_DIR}/nceplibs/${COMPILER}/ -lbacio  -lsp_d  -lw3emc_d  -lw3nco_d"
-elif [ ${CONFIG} = 'shieldfull' ] ; then
-  EXTERNALLIBS="./libfv3.a"
   EXTERNALLIBS+=" ${LIBS_DIR}/libFMS/${COMPILER}/64bit/libFMS.a"
   EXTERNALLIBS+=" ./libgfs.a"
   EXTERNALLIBS+=" -L${LIBS_DIR}/nceplibs/${COMPILER}/ -lbacio  -lsp_d  -lw3emc_d  -lw3nco_d"
@@ -110,15 +105,13 @@ elif [ ${CONFIG} = 'shiemom'  ] ; then
   EXTERNALLIBS+=" -L${LIBS_DIR}/nceplibs/${COMPILER}/ -lbacio  -lsp_d  -lw3emc_d  -lw3nco_d"
 fi
 
-if [ ${CONFIG} = 'shield' ] ||  [ ${CONFIG} = 'shieldfull' ] || [ ${CONFIG} = 'shiemom' ]  ; then
+if [ ${CONFIG} = 'shield' ] || [ ${CONFIG} = 'shiemom' ]  ; then
   (cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y ${COMP} AVX=${AVX} PIC=${PIC} -f Makefile_gfs)
 fi
 
 (cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y NETCDF=3 ${COMP} AVX=${AVX} ${BIT} PIC=${PIC} EXTERNALLIBS="${EXTERNALLIBS}" -f Makefile_fv3)
 
-if   [ ${CONFIG} = 'shieldfull' ] || [ ${CONFIG} = 'shiemom' ] ; then
+if   [ ${CONFIG} = 'shield' ] || [ ${CONFIG} = 'shiemom' ] ; then
    (cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y NETCDF=3 ${COMP} AVX=${AVX} PIC=${PIC} EXTERNALLIBS="${EXTERNALLIBS}" -f Makefile_driver)
-elif [ ${CONFIG} = 'shield' ] ; then
-   (cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y NETCDF=3 ${COMP} AVX=${AVX} ${BIT} PIC=${PIC} EXTERNALLIBS="${EXTERNALLIBS}" -f Makefile_driver)
 fi
 exit 0

--- a/Build/mk_scripts/mk_makefile
+++ b/Build/mk_scripts/mk_makefile
@@ -36,7 +36,7 @@ COMPILER="intel"
 for arg in "$@"
 do
     case $arg in
-        shield|solo|shieldfull|shiemom)
+        shield|solo|shiemom)
         CONFIG="${arg#*=}"
         shift # Remove CONFIG from processing
         ;;
@@ -68,9 +68,8 @@ GFS_cppDefs="-DNEW_TAUCTMAX -DNEMS_GSM -DINTERNAL_FILE_NML"
 #
 # FV3 CPPDEFS
 FV3_cppDefs="-Duse_libMPI -Duse_netCDF -DHAVE_SCHED_GETAFFINITY -DSPMD -Duse_LARGEFILE -DINTERNAL_FILE_NML"
-if [ ${CONFIG} = 'shield' ] ; then
-  FV3_cppDefs+=" -DGFS_PHYS -DUSE_GFSL63"
-elif [ ${CONFIG} = 'shieldfull' ] || [ ${CONFIG} = 'shiemom' ]  ; then
+
+if [ ${CONFIG} = 'shield' ] || [ ${CONFIG} = 'shiemom' ]  ; then
   FV3_cppDefs+=" -DGFS_PHYS -DUSE_GFSL63 -D_USE_LEGACY_LAND_"
 elif [ ${CONFIG} = 'solo' ] ; then
   FV3_cppDefs+=" -DDCMIP -DDYCORE_SOLO -DHIWPP"
@@ -89,33 +88,23 @@ pushd exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/
 ############################
 #---CREATE MAKEFILES
 ############################
-if [ ${CONFIG} = 'shield' ] || [ ${CONFIG} = 'shieldfull' ]  ; then
-  mkmf -m Makefile_gfs -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -o "-cpp" -c "${GFS_cppDefs}" \
+if [ ${CONFIG} = 'shield' ]  ; then
+   mkmf -m Makefile_gfs -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -o "-cpp" -c "${GFS_cppDefs}" \
            -p libgfs.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_gfs
 
-  if [ ${CONFIG} = 'shield' ]  ; then
-    mkmf -m Makefile_fv3 -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" \
-             -o "-I${SHiELD_SRC}/FMS/include -I${LIBS_DIR}/libFMS/${COMPILER}/${BIT}" -c "${FV3_cppDefs}" \
-             -p libfv3.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3
-    mkmf -m Makefile_driver -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "${FV3_cppDefs}" \
-             -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${LIBS_DIR}/libFMS/${COMPILER}/${BIT}" \
-             ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver
-  elif [ ${CONFIG} = 'shieldfull' ] ; then
    mkmf -m Makefile_fv3 -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" \
-             -o "-I${SHiELD_SRC}/FMS/include -I${SHiELD_SRC}/GFDL_atmos_cubed_sphere/driver/SHiELDFULL/include -I${LIBS_DIR}/libFMS/${COMPILER}/64bit" -c "${FV3_cppDefs}" \
+             -o "-I${SHiELD_SRC}/FMS/include -I${SHiELD_SRC}/GFDL_atmos_cubed_sphere/driver/SHiELD/include -I${LIBS_DIR}/libFMS/${COMPILER}/64bit" -c "${FV3_cppDefs}" \
              -p libfv3.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3
    mkmf -m Makefile_driver -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "${FV3_cppDefs}" \
              -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${LIBS_DIR}/libFMS/${COMPILER}/64bit" \
              ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver
-  fi
-
 
 elif [ ${CONFIG} = 'shiemom' ] ; then
   mkmf -m Makefile_gfs -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -o "-cpp" -c "${GFS_cppDefs}" \
            -p libgfs.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_gfs
 
   mkmf -m Makefile_fv3 -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" \
-           -o "-I${SHiELD_SRC}/FMS/include -I${SHiELD_SRC}/GFDL_atmos_cubed_sphere/driver/SHiELDFULL/include -I${LIBS_DIR}/libFMS/${COMPILER}/64bit" -c "${FV3_cppDefs}" \
+           -o "-I${SHiELD_SRC}/FMS/include -I${SHiELD_SRC}/GFDL_atmos_cubed_sphere/driver/SHiELD/include -I${LIBS_DIR}/libFMS/${COMPILER}/64bit" -c "${FV3_cppDefs}" \
            -p libfv3.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3
 
   mkmf -m Makefile_driver -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "${FV3_cppDefs}" \
@@ -134,7 +123,7 @@ fi
 sed 's/LDFLAGS/EXTERNALLIBS) $(LDFLAGS/g' < Makefile_fv3 > OUT
 mv OUT Makefile_fv3
 
-if [ ${CONFIG} = 'shield' ] ||  [ ${CONFIG} = 'shieldfull' ] || [ ${CONFIG} = 'shiemom' ] ; then
+if [ ${CONFIG} = 'shield' ] || [ ${CONFIG} = 'shiemom' ] ; then
   sed 's/LDFLAGS/EXTERNALLIBS) $(LDFLAGS/g' < Makefile_driver > OUT
   mv OUT Makefile_driver
 fi
@@ -142,7 +131,7 @@ fi
 #---COMPILE -O0 (for speed)
 #---GFS_diagnostics.F90
 ############################
-if [ ${CONFIG} = 'shield' ] ||  [ ${CONFIG} = 'shieldfull' ]  || [ ${CONFIG} = 'shiemom' ] ; then
+if [ ${CONFIG} = 'shield' ] || [ ${CONFIG} = 'shiemom' ] ; then
   sed -i 's"$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) $(OTHERFLAGS) $(OTHER_FFLAGS) -c\t$(SRCROOT)SHiELD_physics/GFS_layer/GFS_diagnostics.F90" $(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) $(OTHERFLAGS) $(OTHER_FFLAGS) -O0 -c\t$(SRCROOT)SHiELD_physics/GFS_layer/GFS_diagnostics.F90" ' Makefile_gfs
 fi
 

--- a/Build/mk_scripts/mk_paths
+++ b/Build/mk_scripts/mk_paths
@@ -34,7 +34,7 @@ COMPILER="intel"
 for arg in "$@"
 do
     case $arg in
-        shield|solo|shieldfull|shiemom)
+        shield|solo|shiemom)
         CONFIG="${arg#*=}"
         shift # Remove CONFIG from processing
         ;;
@@ -79,33 +79,17 @@ elif [ ${CONFIG} = 'shield' ] ; then
 
   list_paths -o ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3 \
       SHiELD_physics/FV3GFS/ \
-      atmos_drivers/SHiELD/atmos_model.F90 \
-      GFDL_atmos_cubed_sphere/driver/SHiELD/atmosphere.F90 \
-      GFDL_atmos_cubed_sphere/tools/ \
-      GFDL_atmos_cubed_sphere/model/
-
-  list_paths -o ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver \
-      FMSCoupler/SHiELD/coupler_main.F90
-
-elif [ ${CONFIG} = 'shieldfull' ] ; then
-  list_paths -o ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_gfs \
-      SHiELD_physics/gsmphys/  \
-      SHiELD_physics/GFS_layer/ \
-      SHiELD_physics/IPD_layer/
-
-  list_paths -o ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3 \
-      SHiELD_physics/FV3GFS/ \
       GFDL_atmos_cubed_sphere/tools/ \
       GFDL_atmos_cubed_sphere/model/ \
       SHiELD_physics/atmos_shared/  \
-      GFDL_atmos_cubed_sphere/driver/SHiELDFULL/atmosphere.F90
+      GFDL_atmos_cubed_sphere/driver/SHiELD/atmosphere.F90
 
   list_paths -o ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver \
       ocean_null/ \
       ice_null/ \
       ice_param/ \
       land_null/ \
-      atmos_drivers/SHiELDFULL/ \
+      atmos_drivers/SHiELD/ \
       FMSCoupler/full/ \
       FMSCoupler/shared/
 
@@ -121,12 +105,12 @@ elif  [ ${CONFIG} = 'shiemom' ] ; then
       GFDL_atmos_cubed_sphere/tools/ \
       GFDL_atmos_cubed_sphere/model/ \
       SHiELD_physics/atmos_shared/  \
-      GFDL_atmos_cubed_sphere/driver/SHiELDFULL/atmosphere.F90
+      GFDL_atmos_cubed_sphere/driver/SHiELD/atmosphere.F90
 
   list_paths -o ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver \
       land_null/ \
-      atmos_drivers/SHiELDFULL/ \
-      GFDL_atmos_cubed_sphere/driver/SHiELDFULL/atmosphere.F90 \
+      atmos_drivers/SHiELD/ \
+      GFDL_atmos_cubed_sphere/driver/SHiELD/atmosphere.F90 \
       FMSCoupler/full/ \
       FMSCoupler/shared/
 

--- a/CHECKOUT_code
+++ b/CHECKOUT_code
@@ -82,8 +82,8 @@ release="FV3-202411-public"
 
 fv3_release=$release
 phy_release=$release
-fms_release="2024.03"
-fms_c_release="2024.03.01"
+fms_release="2025.01"
+fms_c_release="2025.01.01"
 drivers_release=$release
 
 git clone -b ${fv3_release} https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere

--- a/CHECKOUT_code
+++ b/CHECKOUT_code
@@ -39,16 +39,13 @@ config_name="SHiELD"
 for arg in "$@"
   do
       case $arg in
-          solo|shield|shieldfull|shiemom)
+          solo|shield|shiemom)
              config="${arg#*=}"
              if [ $config = 'solo' ] ; then
                config_name="SOLO"
              fi
              if [ $config = 'shield' ] ; then
                config_name="SHiELD"
-             fi
-             if [ $config = 'shieldfull' ] ; then
-               config_name="SHiELDFULL"
              fi
              if [ $config = 'shiemom' ] ; then
                config_name="SHiEMOM"
@@ -63,7 +60,6 @@ for arg in "$@"
           echo -e "valid options are:"
           echo -e "\t[solo]       \t\t\t SOLO FV3 configuration"
           echo -e "\t[shield]     \t\t\t SHiELD configuration"
-          echo -e "\t[shieldfull] \t\t\t SHiELD with the full coupler configuration"
           echo -e "\t[shiemom]    \t\t\t SHiEMOM (SHiELD+MOM6/SIS2) configuration"
           echo -e "\n"
           exit
@@ -90,12 +86,12 @@ git clone -b ${fv3_release} https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
 git clone -b ${fms_release}   https://github.com/NOAA-GFDL/FMS
 git clone -b ${drivers_release}   https://github.com/NOAA-GFDL/atmos_drivers
 
-if [ $config_name = 'SHiELD' ] || [ $config_name = 'SHiELDFULL' ] || [ $config_name = 'SHiEMOM' ] ; then
+if [ $config_name = 'SHiELD' ] || [ $config_name = 'SHiEMOM' ] ; then
    git clone -b ${phy_release} https://github.com/NOAA-GFDL/SHiELD_physics
    git clone -b ${fms_c_release} https://github.com/NOAA-GFDL/FMSCoupler
 fi
 
-if [ $config_name = 'SHiELDFULL' ] ; then
+if [ $config_name = 'SHiELD' ] ; then
    git clone  https://github.com/NOAA-GFDL/ocean_null
    git clone  https://github.com/NOAA-GFDL/land_null
    git clone  https://github.com/NOAA-GFDL/ice_null

--- a/RTS/GAEA_RTS/C3072_res.csh
+++ b/RTS/GAEA_RTS/C3072_res.csh
@@ -395,12 +395,19 @@ cat >! input.nml <<EOF
        hours = $hours
        seconds = $seconds
        dt_atmos = $dt_atmos
-       dt_ocean = $dt_atmos
+       !dt_ocean = $dt_atmos
        current_date =  $curr_date
        calendar = 'julian'
        atmos_nthreads = $nthreads
        use_hyper_thread = $hyperthread
 !       ncores_per_node = $cores_per_node
+       ice_npes = -1
+       land_npes = -1
+       do_ocean=.False.
+       dt_cpld = $dt_atmos
+       do_flux=.False.
+       do_land=.False.
+       do_ice=.False.
 /
 
  &external_ic_nml 

--- a/RTS/GAEA_RTS/C384.csh
+++ b/RTS/GAEA_RTS/C384.csh
@@ -359,11 +359,18 @@ cat >! input.nml <<EOF
        days  = $days
        hours = $hours
        dt_atmos = $dt_atmos
-       dt_ocean = $dt_atmos
+       !dt_ocean = $dt_atmos
        current_date =  $curr_date
        calendar = 'julian'
        atmos_nthreads = $nthreads
        use_hyper_thread = $hyperthread
+       ice_npes = -1
+       land_npes = -1
+       do_ocean=.False.
+       dt_cpld = $dt_atmos
+       do_flux=.False.
+       do_land=.False.
+       do_ice=.False.
 /
 
  &external_ic_nml

--- a/RTS/GAEA_RTS/C48_res.csh
+++ b/RTS/GAEA_RTS/C48_res.csh
@@ -432,13 +432,20 @@ cat >! input.nml <<EOF
        hours = $hours
        seconds = $seconds
        dt_atmos = $dt_atmos
-       dt_ocean = $dt_atmos
+       !dt_ocean = $dt_atmos
        current_date =  $curr_date
        calendar = 'julian'
        !memuse_verbose = .false.
        atmos_nthreads = $nthreads
        use_hyper_thread = $hyperthread
 !       ncores_per_node = $cores_per_node
+       ice_npes = -1
+       land_npes = -1
+       do_ocean=.False.
+       dt_cpld = $dt_atmos
+       do_flux=.False.
+       do_land=.False.
+       do_ice=.False.
 /
 
  &external_ic_nml 

--- a/RTS/GAEA_RTS/C48_test.csh
+++ b/RTS/GAEA_RTS/C48_test.csh
@@ -364,11 +364,18 @@ cat > input.nml <<EOF
        hours = $hours
        seconds = $seconds
        dt_atmos = $dt_atmos
-       dt_ocean = $dt_atmos
+       !dt_ocean = $dt_atmos
        current_date =  $curr_date
        calendar = 'julian'
        atmos_nthreads = $nthreads
        use_hyper_thread = $hyperthread
+       ice_npes = -1
+       land_npes = -1
+       do_ocean=.False.
+       dt_cpld = $dt_atmos
+       do_flux=.False.
+       do_land=.False.
+       do_ice=.False.
 /
 
  &external_ic_nml

--- a/RTS/GAEA_RTS/C48n4.csh
+++ b/RTS/GAEA_RTS/C48n4.csh
@@ -824,13 +824,19 @@ cat >! input_nest02.nml <<EOF
        minutes = $minutes
        seconds = $seconds
        dt_atmos = $dt_atmos
-       dt_ocean = $dt_atmos
+       !dt_ocean = $dt_atmos
        current_date =  $curr_date
        calendar = 'julian'
        memuse_verbose = .T.
        atmos_nthreads = $nthreads
        use_hyper_thread = $hyperthread
-       ncores_per_node = $cores_per_node
+       ice_npes = -1
+       land_npes = -1
+       do_ocean=.False.
+       dt_cpld = $dt_atmos
+       do_flux=.False.
+       do_land=.False.
+       do_ice=.False.
 /
 
  &external_ic_nml 

--- a/RTS/GAEA_RTS/C768.csh
+++ b/RTS/GAEA_RTS/C768.csh
@@ -354,12 +354,19 @@ cat > input.nml <<EOF
        days  = $days
        hours = $hours
        dt_atmos = $dt_atmos
-       dt_ocean = $dt_atmos
+       !dt_ocean = $dt_atmos
        current_date =  $curr_date
        calendar = 'julian'
        !memuse_verbose = .false.
        atmos_nthreads = $nthreads
        use_hyper_thread = $hyperthread
+       ice_npes = -1
+       land_npes = -1
+       do_ocean=.False.
+       dt_cpld = $dt_atmos
+       do_flux=.False.
+       do_land=.False.
+       do_ice=.False.
 /
 
  &external_ic_nml 

--- a/RTS/GAEA_RTS/C768r15n3.csh
+++ b/RTS/GAEA_RTS/C768r15n3.csh
@@ -419,12 +419,19 @@ flush_nc_files = .true.
        minutes = $minutes
        seconds = $seconds
        dt_atmos = $dt_atmos
-       dt_ocean = $dt_atmos
+       !dt_ocean = $dt_atmos
        current_date =  $curr_date
        calendar = 'julian'
        !memuse_verbose = .false.
        atmos_nthreads = $nthreads
        use_hyper_thread = $hyperthread
+       ice_npes = -1
+       land_npes = -1
+       do_ocean=.False.
+       dt_cpld = $dt_atmos
+       do_flux=.False.
+       do_land=.False.
+       do_ice=.False.
 /
 
  &external_ic_nml 

--- a/RTS/GAEA_RTS/Regional3km.csh
+++ b/RTS/GAEA_RTS/Regional3km.csh
@@ -448,12 +448,19 @@ cat >! input.nml <<EOF
        minutes = $minutes
        seconds = $seconds
        dt_atmos = $dt_atmos
-       dt_ocean = $dt_atmos
+       !dt_ocean = $dt_atmos
        current_date =  $curr_date
        calendar = 'julian'
        !memuse_verbose = .T.
        atmos_nthreads = $nthreads
        use_hyper_thread = $hyperthread
+       ice_npes = -1
+       land_npes = -1
+       do_ocean=.False.
+       dt_cpld = $dt_atmos
+       do_flux=.False.
+       do_land=.False.
+       do_ice=.False.
 /
 
  &external_ic_nml 


### PR DESCRIPTION
This PR removes the old SHiELD infrastructure and renames the new SHiELDFULL configuration, which utilizes the full FMS coupler infrastructure, as SHiELD.

This PR works with:
https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/384
https://github.com/NOAA-GFDL/atmos_drivers/pull/57
