### PR TITLE
Modifying module loads on Gaea platforms for 17 June 2025 PE change.

### DIFF
--- a/site/environment.gnu.csh
+++ b/site/environment.gnu.csh
@@ -37,10 +37,10 @@ switch ($hostname)
        module load   PrgEnv-gnu
        module rm gcc
        module load gcc-native/13.2
-       module load cray-hdf5/1.12.2.11
-       module load cray-netcdf/4.9.0.11
+       module load cray-hdf5/1.14.3.5
+       module load cray-netcdf/4.9.0.17
        module load craype-hugepages4M
-       module load cmake/3.23.1
+       module load cmake/3.27.9
        module load libyaml/0.2.5
 
        # Needed with the new Environment on C5 as of 10/16/2024

--- a/site/environment.gnu.sh
+++ b/site/environment.gnu.sh
@@ -36,10 +36,10 @@ case $hostname in
        module load   PrgEnv-gnu
        module rm gcc
        module load gcc-native/13.2
-       module load cray-hdf5/1.12.2.11
-       module load cray-netcdf/4.9.0.11
+       module load cray-hdf5/1.14.3.5
+       module load cray-netcdf/4.9.0.17
        module load craype-hugepages4M
-       module load cmake/3.23.1
+       module load cmake/3.27.9
        module load libyaml/0.2.5
 
        # Add -DHAVE_GETTID to the FMS cppDefs

--- a/site/environment.intel.csh
+++ b/site/environment.intel.csh
@@ -66,10 +66,10 @@ switch ($hostname)
       module rm gcc
       module load intel-classic/2023.2.0
       module unload cray-libsci
-      module load cray-hdf5/1.12.2.11
-      module load cray-netcdf/4.9.0.11
+      module load cray-hdf5/1.14.3.5
+      module load cray-netcdf/4.9.0.17
       module load craype-hugepages4M
-      module load cmake/3.23.1
+      module load cmake/3.27.9
       module load libyaml/0.2.5
 
       # Needed with the new Environment on C5 as of 10/16/2024

--- a/site/environment.intel.sh
+++ b/site/environment.intel.sh
@@ -43,7 +43,7 @@ case $hostname in
       module load cray-hdf5
       module load cray-netcdf
       module load craype-hugepages4M
-      #module load cmake/3.23.1
+      #module load cmake/3.27.9
       #module load libyaml/0.2.5
 
       # Add -DHAVE_GETTID to the FMS cppDefs
@@ -75,10 +75,10 @@ case $hostname in
       module rm gcc
       module load intel-classic/2023.2.0
       module unload cray-libsci
-      module load cray-hdf5/1.12.2.11
-      module load cray-netcdf/4.9.0.11
+      module load cray-hdf5/1.14.3.5
+      module load cray-netcdf/4.9.0.17
       module load craype-hugepages4M
-      module load cmake/3.23.1
+      module load cmake/3.27.9
       module load libyaml/0.2.5
 
       # Add -DHAVE_GETTID to the FMS cppDefs


### PR DESCRIPTION
**Description**

Gaea has a PE update coming 17 June 2025.  This PR updates the versions of modules loaded on C5/C6 to work on the new PE.  We should merge this on 17 June.

Fixes # (issue)

**How Has This Been Tested?**

Tested the new PE.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
