### PR TITLE
Add missing MARBL path to MOM6

### DIFF
--- a/Build/BUILDmom6
+++ b/Build/BUILDmom6
@@ -88,6 +88,7 @@ list_paths -l -o ${LIBS_DIR}/mom6/${COMPILER}/pathnames_mom6 \
     ${SHiELD_SRC}/MOM6/config_src/external/drifters \
     ${SHiELD_SRC}/MOM6/config_src/external/stochastic_physics \
     ${SHiELD_SRC}/MOM6/config_src/external/GFDL_ocean_BGC \
+    ${SHiELD_SRC}/MOM6/config_src/external/MARBL \
     ${SHiELD_SRC}/MOM6/pkg/GSW-Fortran/*/ \
     ${SHiELD_SRC}/MOM6/config_src/infra/FMS2
 cd ${LIBS_DIR}


### PR DESCRIPTION
Discovered while building SHiELD-MOM6 coupled configuration

**Description**

Include a summary of the change and which issue is fixed. Please also include
relevant motivation and context. List any dependencies that are required for
this change.

Fixes # (issue)

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Please also note
any relevant details for your test configuration (e.g. compiler, OS).  Include
enough information so someone can reproduce your tests.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
