### PR TITLE
Add Stellar environment support

### DIFF
--- a/Build/BUILDmom6
+++ b/Build/BUILDmom6
@@ -88,6 +88,7 @@ list_paths -l -o ${LIBS_DIR}/mom6/${COMPILER}/pathnames_mom6 \
     ${SHiELD_SRC}/MOM6/config_src/external/drifters \
     ${SHiELD_SRC}/MOM6/config_src/external/stochastic_physics \
     ${SHiELD_SRC}/MOM6/config_src/external/GFDL_ocean_BGC \
+    ${SHiELD_SRC}/MOM6/config_src/external/MARBL \
     ${SHiELD_SRC}/MOM6/pkg/GSW-Fortran/*/ \
     ${SHiELD_SRC}/MOM6/config_src/infra/FMS2
 cd ${LIBS_DIR}

--- a/site/environment.intel.csh
+++ b/site/environment.intel.csh
@@ -80,6 +80,30 @@ switch ($hostname)
       echo -e ' '
       module list
       breaksw
+   case stellar*:
+      echo " Stellar environment "
+
+      source ${MODULESHOME}/init/csh
+      module purge
+      module load cmake/3.19.7
+      module load intel/2021.1.2
+      module load openmpi/intel-2021.1/4.1.2
+      module load netcdf/intel-2021.1/hdf5-1.10.6/4.7.4
+      module load hdf5/intel-2021.1/1.10.6
+
+      setenv FMS_CPPDEFS=""
+
+      setenv FC mpif90
+      setenv CC mpicc
+      setenv CXX mpicxx
+      setenv LD mpif90
+      setenv TEMPLATE site/intel.mk
+      setenv LAUNCHER srun
+      setenv AVX_LEVEL -march=core-avx2
+
+      echo -e " "
+      module list
+      breaksw
    default:
       echo " no environment available based on the hostname "
       breaksw


### PR DESCRIPTION
**Description**
Added support for Stellar environment via 'environment.intel.csh', based on 'environment.stellar.sh' provided by Joseph.  This update ensures SHiELD can be compiled and run on the Stellar.

Fixes # (issue)

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Please also note
any relevant details for your test configuration (e.g. compiler, OS).  Include
enough information so someone can reproduce your tests.

**Checklist:**

Please check all whether they apply or not
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
