### PR TITLE
Add Stellar environment support 

### DIFF
--- a/site/environment.intel.csh
+++ b/site/environment.intel.csh
@@ -80,6 +80,30 @@ switch ($hostname)
       echo -e ' '
       module list
       breaksw
+ case stellar*:
+      echo " Stellar environment "
+
+      source ${MODULESHOME}/init/csh
+      module purge
+      module load cmake/3.19.7
+      module load intel/2021.1.2
+      module load openmpi/intel-2021.1/4.1.2
+      module load netcdf/intel-2021.1/hdf5-1.10.6/4.7.4
+      module load hdf5/intel-2021.1/1.10.6
+
+      setenv FMS_CPPDEFS=""
+
+      setenv FC mpif90
+      setenv CC mpicc
+      setenv CXX mpicxx
+      setenv LD mpif90
+      setenv TEMPLATE site/intel.mk
+      setenv LAUNCHER srun
+      setenv AVX_LEVEL -march=core-avx2
+
+      echo -e " "
+      module list
+      breaksw
    default:
       echo " no environment available based on the hostname "
       breaksw


### PR DESCRIPTION
Added Stellar environment support in **environment.intel.csh**, using environment variable settings provided by @JosephMouallem as a reference. This enables SHiELD to compile and run properly on Stellar.