### PR TITLE
Gaea hdf5 workaround

### DIFF
--- a/site/environment.intel.csh
+++ b/site/environment.intel.csh
@@ -48,7 +48,7 @@ switch ($hostname)
       #module load libyaml/0.2.5
 
       setenv LAUNCHER "srun"
-      setenv LD_LIBRARY_PATH ${NETCDF_DIR}/lib:${HDF5_DIR}/lib:${LD_LIBRARY_PATH}
+      setenv LD_LIBRARY_PATH ${CRAY_LD_LIBRARY_PATH}:${LD_LIBRARY_PATH}
 
       echo -e ' '
       module list
@@ -77,7 +77,7 @@ switch ($hostname)
       setenv FI_VERBS_PREFER_XRC 0
 
       setenv LAUNCHER "srun"
-      setenv LD_LIBRARY_PATH ${NETCDF_DIR}/lib:${HDF5_DIR}/lib:${LD_LIBRARY_PATH}
+      setenv LD_LIBRARY_PATH ${CRAY_LD_LIBRARY_PATH}:${LD_LIBRARY_PATH}
 
       echo -e ' '
       module list

--- a/site/environment.intel.csh
+++ b/site/environment.intel.csh
@@ -41,8 +41,8 @@ switch ($hostname)
       module rm gcc
       module load intel-classic/2023.2.0
       module unload cray-libsci
-      module load cray-hdf5
-      module load cray-netcdf
+      module load cray-hdf5/1.12.2.11
+      module load cray-netcdf/4.9.0.9
       module load craype-hugepages4M
       #module load cmake/3.23.1
       #module load libyaml/0.2.5
@@ -66,8 +66,8 @@ switch ($hostname)
       module rm gcc
       module load intel-classic/2023.2.0
       module unload cray-libsci
-      module load cray-hdf5/1.14.3.5
-      module load cray-netcdf/4.9.0.17
+      module load cray-hdf5/1.12.2.11
+      module load cray-netcdf/4.9.0.9
       module load craype-hugepages4M
       module load cmake/3.27.9
       module load libyaml/0.2.5

--- a/site/environment.intel.csh
+++ b/site/environment.intel.csh
@@ -48,6 +48,7 @@ switch ($hostname)
       #module load libyaml/0.2.5
 
       setenv LAUNCHER "srun"
+      setenv LD_LIBRARY_PATH ${NETCDF_DIR}/lib:${HDF5_DIR}/lib:${LD_LIBRARY_PATH}
 
       echo -e ' '
       module list
@@ -76,6 +77,7 @@ switch ($hostname)
       setenv FI_VERBS_PREFER_XRC 0
 
       setenv LAUNCHER "srun"
+      setenv LD_LIBRARY_PATH ${NETCDF_DIR}/lib:${HDF5_DIR}/lib:${LD_LIBRARY_PATH}
 
       echo -e ' '
       module list

--- a/site/environment.intel.sh
+++ b/site/environment.intel.sh
@@ -57,6 +57,9 @@ case $hostname in
       export TEMPLATE=site/intel.mk
       export LAUNCHER=srun
 
+      #need to add this for dynamically linking on GAEA
+      export LD_LIBRARY_PATH=${CRAY_LD_LIBRARY_PATH}:${LD_LIBRARY_PATH}
+
       # highest level of AVX support
       export AVX_LEVEL=-march=core-avx-i
       echo -e ' '
@@ -93,6 +96,9 @@ case $hostname in
       export LD=ftn
       export TEMPLATE=site/intel.mk
       export LAUNCHER=srun
+
+      #need to add this for dynamically linking on GAEA
+      export LD_LIBRARY_PATH=${CRAY_LD_LIBRARY_PATH}:${LD_LIBRARY_PATH}
 
       # highest level of AVX support
       export AVX_LEVEL=-march=core-avx-i

--- a/site/environment.intel.sh
+++ b/site/environment.intel.sh
@@ -40,8 +40,8 @@ case $hostname in
       module rm gcc
       module load intel-classic/2023.2.0
       module unload cray-libsci
-      module load cray-hdf5
-      module load cray-netcdf
+      module load cray-hdf5/1.12.2.11
+      module load cray-netcdf/4.9.0.9
       module load craype-hugepages4M
       #module load cmake/3.27.9
       #module load libyaml/0.2.5
@@ -75,8 +75,8 @@ case $hostname in
       module rm gcc
       module load intel-classic/2023.2.0
       module unload cray-libsci
-      module load cray-hdf5/1.14.3.5
-      module load cray-netcdf/4.9.0.17
+      module load cray-hdf5/1.12.2.1
+      module load cray-netcdf/4.9.0.9
       module load craype-hugepages4M
       module load cmake/3.27.9
       module load libyaml/0.2.5

--- a/site/environment.intel.sh
+++ b/site/environment.intel.sh
@@ -75,7 +75,7 @@ case $hostname in
       module rm gcc
       module load intel-classic/2023.2.0
       module unload cray-libsci
-      module load cray-hdf5/1.12.2.1
+      module load cray-hdf5/1.12.2.11
       module load cray-netcdf/4.9.0.9
       module load craype-hugepages4M
       module load cmake/3.27.9


### PR DESCRIPTION
**Description**

Compiling and running with an older version of hdf5 and netcdf should get us around a debug runtime hdf5 related crash.

Fixes # (issue)

**How Has This Been Tested?**



**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
