### PR TITLE
Add LM4 land model infrastructure for SHiELD-MOM6-SIS2 coupling

### DIFF
--- a/Build/BUILDlm4
+++ b/Build/BUILDlm4
@@ -1,0 +1,110 @@
+#!/bin/bash
+#***********************************************************************
+#*                   GNU Lesser General Public License
+#*
+#* This file is part of the SHiELD Build System.
+#*
+#* The SHiELD Build System free software: you can redistribute it
+#* and/or modify it under the terms of the
+#* GNU Lesser General Public License as published by the
+#* Free Software Foundation, either version 3 of the License, or
+#* (at your option) any later version.
+#*
+#* The SHiELD Build System distributed in the hope that it will be
+#* useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+#* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#* See the GNU General Public License for more details.
+#*
+#* You should have received a copy of the GNU Lesser General Public
+#* License along with theSHiELD Build System
+#* If not, see <http://www.gnu.org/licenses/>.
+#***********************************************************************
+#
+#  DISCLAIMER: This script is provided as-is and as such is unsupported.
+#
+set -x
+#
+# set default values
+# configure your build parameters
+  COMPILER="intel"
+  BIT="64bit"
+  COMP="" # implies PROD=Y
+#
+# parse arguments
+  for arg in "$@"
+  do
+      case $arg in
+        prod|repro|debug)
+          if [ ${arg#} = 'repro' ] ; then
+            COMP="REPRO=Y"
+          elif [ ${arg#} = 'debug' ] ; then
+            COMP="DEBUG=Y"
+          fi
+          shift # Remove COMP from processing
+          ;;
+          intel|gnu)
+             COMPILER="${arg#*=}"
+             shift # Remove "compiler" from processing
+             ;;
+          *)
+          if [ ${arg#} != '--help' ] && [ ${arg#} != '-h' ] ; then
+            echo "option "${arg#}" not found"
+          fi
+          echo -e ' '
+          echo -e "valid options are:"
+          echo -e "\t[intel(D) | gnu] \t\t\t compiler"
+          echo -e "\t[prod(D) | repro | debug] \t\t compiler option settings"
+          echo -e "\n"
+          exit
+          ;;
+      esac
+  done
+
+#
+# set up some default variables if not called from COMPILE
+# BUILD_ROOT is set if this script is called from the COMPILE script
+if [ -z ${BUILD_ROOT} ] ; then
+   export BUILD_ROOT=${PWD%/*}
+   export SHiELD_SRC=${PWD%/*/*}/SHiELD_SRC/
+   export PATH="${BUILD_ROOT}/mkmf/bin:${BUILD_ROOT}/Build/mk_scripts:${PATH}"
+   export LIBS_DIR=${BUILD_ROOT}/Build
+   if [ ! -z ${EXTERNAL_LIBS} ] ; then
+      export LIBS_DIR=${EXTERNAL_LIBS}
+   fi
+   # load the proper environment for your machine
+   . ${BUILD_ROOT}/site/environment.${COMPILER}.sh
+fi
+
+
+
+mkdir -p ${LIBS_DIR}/lm4/${COMPILER}
+list_paths -l -o ${LIBS_DIR}/lm4/${COMPILER}/pathnames_lm4 \
+    ${SHiELD_SRC}/LM4p 
+cd ${LIBS_DIR}
+
+pushd lm4/${COMPILER}
+
+ 
+mkmf -m Makefile -a ${SHiELD_SRC} -p liblm4.a -t "${BUILD_ROOT}/${TEMPLATE}" \
+     -c "-DINTERNAL_FILE_NML -Duse_yaml -Duse_netCDF -DDEBUG_LAND_TILE_DIAG" -o "-I${LIBS_DIR}/libFMS/${COMPILER}/${BIT}/"  -I${SHiELD_SRC}/FMS/amip_interp/include  -I${SHiELD_SRC}/FMS/astronomy/include \
+     -I${SHiELD_SRC}/FMS/axis_utils/include -I${SHiELD_SRC}/FMS/column_diagnostics/include -I${SHiELD_SRC}/FMS/include \
+     -I${SHiELD_SRC}/FMS/data_override/include -I${SHiELD_SRC}/FMS/diag_integral/include -I${SHiELD_SRC}/FMS/diag_manager/include -I${SHiELD_SRC}/FMS/field_manager/include \
+     -I${SHiELD_SRC}/FMS/fms/include -I${SHiELD_SRC}/FMS/fms2_io/include -I${SHiELD_SRC}/FMS/horiz_interp/include -I${SHiELD_SRC}/FMS/include -I${SHiELD_SRC}/FMS/interpolator/include \
+     -I${SHiELD_SRC}/FMS/monin_obukhov/include -I${SHiELD_SRC}/FMS/mosaic2/include -I${SHiELD_SRC}/FMS/mpp/include -I${SHiELD_SRC}/FMS/random_numbers/include -I${SHiELD_SRC}/FMS/sat_vapor_pres/include \
+     -I${SHiELD_SRC}/FMS/string_utils/include -I${SHiELD_SRC}/FMS/test_fms/data_override/include -I${SHiELD_SRC}/FMS/test_fms/fms/include -I${SHiELD_SRC}/FMS/time_interp/include \
+     -I${SHiELD_SRC}/FMS/topography/include -I${SHiELD_SRC}/FMS/tracer_manager/include -I${SHiELD_SRC}/FMS/tridiagonal/include ${LIBS_DIR}/lm4/${COMPILER}/pathnames_lm4
+ 
+make -j8 ${COMP} AVX=Y NETCDF=3 Makefile liblm4.a >& Build_lm4.out
+
+################
+#will get noise with openmp in debugmode
+################
+
+# test and report on libFMS build success
+if [ $? -ne 0 ] ; then
+  echo ">>> ${LIBS_DIR}/lm4/${COMPILER} build failed"
+  exit 1
+fi
+echo " liblm4 build successful"
+
+popd

--- a/Build/BUILDlm4
+++ b/Build/BUILDlm4
@@ -42,21 +42,21 @@ set -x
           fi
           shift # Remove COMP from processing
           ;;
-          intel|gnu)
-             COMPILER="${arg#*=}"
-             shift # Remove "compiler" from processing
-             ;;
-          *)
-          if [ ${arg#} != '--help' ] && [ ${arg#} != '-h' ] ; then
-            echo "option "${arg#}" not found"
-          fi
-          echo -e ' '
-          echo -e "valid options are:"
-          echo -e "\t[intel(D) | gnu] \t\t\t compiler"
-          echo -e "\t[prod(D) | repro | debug] \t\t compiler option settings"
-          echo -e "\n"
-          exit
+        intel|gnu)
+          COMPILER="${arg#*=}"
+          shift # Remove "compiler" from processing
           ;;
+        *)
+        if [ ${arg#} != '--help' ] && [ ${arg#} != '-h' ] ; then
+          echo "option "${arg#}" not found"
+        fi
+        echo -e ' '
+        echo -e "valid options are:"
+        echo -e "\t[intel(D) | gnu] \t\t\t compiler"
+        echo -e "\t[prod(D) | repro | debug] \t\t compiler option settings"
+        echo -e "\n"
+        exit
+        ;;
       esac
   done
 

--- a/Build/COMPILE
+++ b/Build/COMPILE
@@ -64,13 +64,16 @@ spin()
   for arg in "$@"
   do
       case $arg in
-          shield|solo|shield|shiemom)
+          shield|solo|shield|shiemom|shiemom_lm4)
              config="${arg#*=}"
              if [ $config = 'solo' ] ; then
                config_name="SOLO"
              fi
              if [ $config = 'shiemom' ] ; then
                config_name="SHiEMOM"
+             fi
+             if [ $config = 'shiemom_lm4' ] ; then
+               config_name="SHiEMOM_LM4"
              fi
              shift # Remove "config" from processing
              ;;
@@ -118,7 +121,7 @@ spin()
           fi
           echo -e ' '
           echo -e "valid options are:"
-          echo -e "\t[shield(D)  | solo | shiemom] \t\t\t configuration"
+          echo -e "\t[shield(D)  | solo | shiemom | shiemom_lm4] \t\t\t configuration"
           echo -e "\t[nh(D) | hydro | sw] \t\t\t executable configuration"
           echo -e "\t[prod(D) | repro | debug] \t\t compiler option settings"
           echo -e "\t[32bit(D) | 64bit] \t\t\t FV3 precision option"
@@ -141,6 +144,12 @@ if [ $compiler = "nvhpc" ] && [ $config = "shiemom" ] ; then
   echo -e ">>> option '$compiler' with '$config' is not a valid configuration"
   exit 1
 fi
+
+if [ $compiler = "nvhpc" ] && [ $config = "shiemom_lm4" ] ; then
+  echo -e ">>> option '$compiler' with '$config' is not a valid configuration"
+  exit 1
+fi
+
 
 #
 # set up some default variables for use within the helper scripts
@@ -241,7 +250,7 @@ fi
      fi
   fi
 
-if [ $config = "shiemom" ] ; then
+if [ $config = "shiemom" ] || [ $config = "shiemom_lm4" ]  ; then
 # from lauren
   # I think mom6 needs to be built in 64bit for now?
   # I can only get it to compiler with 64bit FMS
@@ -269,6 +278,20 @@ if [ $config = "shiemom" ] ; then
      fi
      echo "DONE WITH SIS2"
   fi
+fi
+
+if [ $config = "shiemom_lm4" ] ; then
+  if [ -d ${LIBS_DIR}/lm4/${compiler} ] && [ -e ${LIBS_DIR}/lm4/${compiler}/liblm4.a ] ; then
+       echo " pre-built ${LIBS_DIR}/lm4/${compiler} exists"
+    else
+       echo " ${LIBS_DIR}/lm4/${compiler} does not exist"
+       ./BUILDlm4 ${comp} ${compiler}
+       if [ $? -ne 0 ] ; then
+          echo " LM4 build failed"
+          exit
+       fi
+       echo "DONE WITH LM4"
+    fi
 fi
 
 #

--- a/Build/mk_scripts/mk_make
+++ b/Build/mk_scripts/mk_make
@@ -41,7 +41,7 @@ pic="nopic"
 for arg in "$@"
 do
     case $arg in
-        shield|solo|shiemom)
+        shield|solo|shiemom|shiemom_lm4)
           CONFIG="${arg#*=}"
           shift # Remove CONFIG from processing
           ;;
@@ -103,15 +103,23 @@ elif [ ${CONFIG} = 'shiemom'  ] ; then
   EXTERNALLIBS+=" ${LIBS_DIR}/libFMS/${COMPILER}/64bit/libFMS.a"
   EXTERNALLIBS+=" ./libgfs.a"
   EXTERNALLIBS+=" -L${LIBS_DIR}/nceplibs/${COMPILER}/ -lbacio  -lsp_d  -lw3emc_d  -lw3nco_d"
+elif [ ${CONFIG} = 'shiemom_lm4'  ] ; then
+  EXTERNALLIBS="./libfv3.a"
+  EXTERNALLIBS+=" ${LIBS_DIR}/sis2/${COMPILER}/libsis2.a"
+  EXTERNALLIBS+=" ${LIBS_DIR}/mom6/${COMPILER}/libmom6.a"
+  EXTERNALLIBS+=" ${LIBS_DIR}/lm4/${COMPILER}/liblm4.a"
+  EXTERNALLIBS+=" ${LIBS_DIR}/libFMS/${COMPILER}/64bit/libFMS.a"
+  EXTERNALLIBS+=" ./libgfs.a"
+  EXTERNALLIBS+=" -L${LIBS_DIR}/nceplibs/${COMPILER}/ -lbacio  -lsp_d  -lw3emc_d  -lw3nco_d"
 fi
 
-if [ ${CONFIG} = 'shield' ] || [ ${CONFIG} = 'shiemom' ]  ; then
+if [ ${CONFIG} = 'shield' ] || [ ${CONFIG} = 'shiemom' ] ||  [ ${CONFIG} = 'shiemom_lm4' ]   ; then
   (cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y ${COMP} AVX=${AVX} PIC=${PIC} -f Makefile_gfs)
 fi
 
 (cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y NETCDF=3 ${COMP} AVX=${AVX} ${BIT} PIC=${PIC} EXTERNALLIBS="${EXTERNALLIBS}" -f Makefile_fv3)
 
-if   [ ${CONFIG} = 'shield' ] || [ ${CONFIG} = 'shiemom' ] ; then
+if   [ ${CONFIG} = 'shield' ] || [ ${CONFIG} = 'shiemom' ] || [ ${CONFIG} = 'shiemom_lm4' ]  ; then
    (cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y NETCDF=3 ${COMP} AVX=${AVX} PIC=${PIC} EXTERNALLIBS="${EXTERNALLIBS}" -f Makefile_driver)
 fi
 exit 0

--- a/Build/mk_scripts/mk_makefile
+++ b/Build/mk_scripts/mk_makefile
@@ -101,7 +101,7 @@ if [ ${CONFIG} = 'shield' ]  ; then
              -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${LIBS_DIR}/libFMS/${COMPILER}/64bit" \
              ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver
 
-elif [ ${CONFIG} = 'shiemom' ] || [ ${CONFIG} = 'shiemom_lm4' ]; then
+elif [ ${CONFIG} = 'shiemom' ]; then
   mkmf -m Makefile_gfs -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -o "-cpp" -c "${GFS_cppDefs}" \
            -p libgfs.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_gfs
 
@@ -112,6 +112,19 @@ elif [ ${CONFIG} = 'shiemom' ] || [ ${CONFIG} = 'shiemom_lm4' ]; then
   mkmf -m Makefile_driver -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "${FV3_cppDefs}" \
            -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${LIBS_DIR}/libFMS/${COMPILER}/64bit -I${LIBS_DIR}/mom6/${COMPILER} -I${LIBS_DIR}/sis2/${COMPILER}" \
            ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver
+
+elif [ ${CONFIG} = 'shiemom_lm4' ]; then
+  mkmf -m Makefile_gfs -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -o "-cpp" -c "${GFS_cppDefs}" \
+           -p libgfs.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_gfs
+
+  mkmf -m Makefile_fv3 -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" \
+           -o "-I${SHiELD_SRC}/FMS/include -I${SHiELD_SRC}/GFDL_atmos_cubed_sphere/driver/SHiELD/include -I${LIBS_DIR}/libFMS/${COMPILER}/64bit" -c "${FV3_cppDefs}" \
+           -p libfv3.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3
+
+  mkmf -m Makefile_driver -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "${FV3_cppDefs}" \
+           -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${LIBS_DIR}/libFMS/${COMPILER}/64bit -I${LIBS_DIR}/mom6/${COMPILER} -I${LIBS_DIR}/sis2/${COMPILER} -I${LIBS_DIR}/lm4/${COMPILER}" \
+           ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver
+
 
 elif [ ${CONFIG} = 'solo' ] ; then
   mkmf -m Makefile_fv3 -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "${FV3_cppDefs}" \

--- a/Build/mk_scripts/mk_makefile
+++ b/Build/mk_scripts/mk_makefile
@@ -36,7 +36,7 @@ COMPILER="intel"
 for arg in "$@"
 do
     case $arg in
-        shield|solo|shiemom)
+        shield|solo|shiemom|shiemom_lm4)
         CONFIG="${arg#*=}"
         shift # Remove CONFIG from processing
         ;;
@@ -69,8 +69,10 @@ GFS_cppDefs="-DNEW_TAUCTMAX -DNEMS_GSM -DINTERNAL_FILE_NML"
 # FV3 CPPDEFS
 FV3_cppDefs="-Duse_libMPI -Duse_netCDF -DHAVE_SCHED_GETAFFINITY -DSPMD -Duse_LARGEFILE -DINTERNAL_FILE_NML"
 
-if [ ${CONFIG} = 'shield' ] || [ ${CONFIG} = 'shiemom' ]  ; then
+if [ ${CONFIG} = 'shield' ] || [ ${CONFIG} = 'shiemom' ]; then
   FV3_cppDefs+=" -DGFS_PHYS -DUSE_GFSL63 -D_USE_LEGACY_LAND_"
+elif [ ${CONFIG} = 'shiemom_lm4' ] ; then
+  FV3_cppDefs+=" -DGFS_PHYS -DUSE_GFSL63"
 elif [ ${CONFIG} = 'solo' ] ; then
   FV3_cppDefs+=" -DDCMIP -DDYCORE_SOLO -DHIWPP"
 fi
@@ -99,7 +101,7 @@ if [ ${CONFIG} = 'shield' ]  ; then
              -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${LIBS_DIR}/libFMS/${COMPILER}/64bit" \
              ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver
 
-elif [ ${CONFIG} = 'shiemom' ] ; then
+elif [ ${CONFIG} = 'shiemom' ] || [ ${CONFIG} = 'shiemom_lm4' ]; then
   mkmf -m Makefile_gfs -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -o "-cpp" -c "${GFS_cppDefs}" \
            -p libgfs.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_gfs
 
@@ -123,7 +125,7 @@ fi
 sed 's/LDFLAGS/EXTERNALLIBS) $(LDFLAGS/g' < Makefile_fv3 > OUT
 mv OUT Makefile_fv3
 
-if [ ${CONFIG} = 'shield' ] || [ ${CONFIG} = 'shiemom' ] ; then
+if [ ${CONFIG} = 'shield' ] || [ ${CONFIG} = 'shiemom' ] || [ ${CONFIG} = 'shiemom_lm4' ]; then
   sed 's/LDFLAGS/EXTERNALLIBS) $(LDFLAGS/g' < Makefile_driver > OUT
   mv OUT Makefile_driver
 fi
@@ -131,7 +133,7 @@ fi
 #---COMPILE -O0 (for speed)
 #---GFS_diagnostics.F90
 ############################
-if [ ${CONFIG} = 'shield' ] || [ ${CONFIG} = 'shiemom' ] ; then
+if [ ${CONFIG} = 'shield' ] || [ ${CONFIG} = 'shiemom' ] || [ ${CONFIG} = 'shiemom_lm4' ]; then
   sed -i 's"$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) $(OTHERFLAGS) $(OTHER_FFLAGS) -c\t$(SRCROOT)SHiELD_physics/GFS_layer/GFS_diagnostics.F90" $(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) $(OTHERFLAGS) $(OTHER_FFLAGS) -O0 -c\t$(SRCROOT)SHiELD_physics/GFS_layer/GFS_diagnostics.F90" ' Makefile_gfs
 fi
 

--- a/Build/mk_scripts/mk_paths
+++ b/Build/mk_scripts/mk_paths
@@ -34,7 +34,7 @@ COMPILER="intel"
 for arg in "$@"
 do
     case $arg in
-        shield|solo|shiemom)
+        shield|solo|shiemom|shiemom_lm4)
         CONFIG="${arg#*=}"
         shift # Remove CONFIG from processing
         ;;
@@ -114,6 +114,26 @@ elif  [ ${CONFIG} = 'shiemom' ] ; then
       FMSCoupler/full/ \
       FMSCoupler/shared/
 
+elif  [ ${CONFIG} = 'shiemom_lm4' ] ; then
+
+  list_paths -o ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_gfs \
+      SHiELD_physics/gsmphys/  \
+      SHiELD_physics/GFS_layer/ \
+      SHiELD_physics/IPD_layer/
+
+  list_paths -o ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3 \
+      SHiELD_physics/FV3GFS/ \
+      GFDL_atmos_cubed_sphere/tools/ \
+      GFDL_atmos_cubed_sphere/model/ \
+      SHiELD_physics/atmos_shared/  \
+      GFDL_atmos_cubed_sphere/driver/SHiELD/atmosphere.F90
+
+  list_paths -o ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver \
+      LM4p/ \
+      atmos_drivers/SHiELD/ \
+      GFDL_atmos_cubed_sphere/driver/SHiELD/atmosphere.F90 \
+      FMSCoupler/full/ \
+      FMSCoupler/shared/
 fi
 
 popd

--- a/Build/mk_scripts/mk_paths
+++ b/Build/mk_scripts/mk_paths
@@ -129,7 +129,6 @@ elif  [ ${CONFIG} = 'shiemom_lm4' ] ; then
       GFDL_atmos_cubed_sphere/driver/SHiELD/atmosphere.F90
 
   list_paths -o ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver \
-      LM4p/ \
       atmos_drivers/SHiELD/ \
       GFDL_atmos_cubed_sphere/driver/SHiELD/atmosphere.F90 \
       FMSCoupler/full/ \

--- a/CHECKOUT_code
+++ b/CHECKOUT_code
@@ -39,7 +39,7 @@ config_name="SHiELD"
 for arg in "$@"
   do
       case $arg in
-          solo|shield|shiemom)
+          solo|shield|shiemom|shiemom_lm4)
              config="${arg#*=}"
              if [ $config = 'solo' ] ; then
                config_name="SOLO"
@@ -49,6 +49,9 @@ for arg in "$@"
              fi
              if [ $config = 'shiemom' ] ; then
                config_name="SHiEMOM"
+             fi
+             if [ $config = 'shiemom_lm4' ] ; then
+               config_name="SHiEMOM_LM4"
              fi
              shift # Remove "config" from processing
              ;;
@@ -61,6 +64,7 @@ for arg in "$@"
           echo -e "\t[solo]       \t\t\t SOLO FV3 configuration"
           echo -e "\t[shield]     \t\t\t SHiELD configuration"
           echo -e "\t[shiemom]    \t\t\t SHiEMOM (SHiELD+MOM6/SIS2) configuration"
+          echo -e "\t[shiemom_lm4]    \t\t\t SHiEMOM_LM4 (SHiELD+MOM6/SIS2+LM4) configuration"
           echo -e "\n"
           exit
           ;;
@@ -81,26 +85,32 @@ phy_release=$release
 fms_release="2025.01"
 fms_c_release="2025.01.01"
 drivers_release=$release
+land_release="2025.02"
 
 git clone -b ${fv3_release} https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere
 git clone -b ${fms_release}   https://github.com/NOAA-GFDL/FMS
 git clone -b ${drivers_release}   https://github.com/NOAA-GFDL/atmos_drivers
 
-if [ $config_name = 'SHiELD' ] || [ $config_name = 'SHiEMOM' ] ; then
+if [ $config_name = 'SHiELD' ] || [ $config_name = 'SHiEMOM' ] || [ $config_name = 'SHiEMOM_LM4' ] ; then
    git clone -b ${phy_release} https://github.com/NOAA-GFDL/SHiELD_physics
    git clone -b ${fms_c_release} https://github.com/NOAA-GFDL/FMSCoupler
+   git clone  https://github.com/NOAA-GFDL/ice_param
 fi
 
 if [ $config_name = 'SHiELD' ] ; then
    git clone  https://github.com/NOAA-GFDL/ocean_null
    git clone  https://github.com/NOAA-GFDL/land_null
    git clone  https://github.com/NOAA-GFDL/ice_null
-   git clone  https://github.com/NOAA-GFDL/ice_param
 fi
 
 if [ $config_name = 'SHiEMOM' ] ; then
    git clone  https://github.com/NOAA-GFDL/land_null
-   git clone  https://github.com/NOAA-GFDL/ice_param
+   cd ../SHiELD_build/
+   ./CHECKOUT_mom6.csh
+fi
+
+if [ $config_name = 'SHiEMOM_LM4' ] ; then
+   git clone --recursive -b ${land_release} http://gitlab.gfdl.noaa.gov/fms/lm4p.git LM4p
    cd ../SHiELD_build/
    ./CHECKOUT_mom6.csh
 fi

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ Be sure to download the mkmf submodule prior to beginning.  To use:
  2) cd Build and execute ./COMPILE script with the --help option to see usage
 
  3) COMPILE:
-    - ./COMPILE shield:     will compile shield with simple coupler
-    - ./COMPILE shieldfull: will compile shield with full coupler (utilizing null modules for ocean, land, ice)
+    - ./COMPILE shield: will compile shield with full coupler (utilizing null modules for ocean, land, ice)
     - ./COMPILE shiemom:    will compile mom6, sis2, fv3, gfs as libraries and link them to the full coupler (no null ocean and ice modules.)
 
       Example: ./COMPILE shield nh repro 32bit intel


### PR DESCRIPTION
This PR adds a new checkout and compile option called `shiemom_lm4` which introduces the land model LM4 to SHiELD-MOM6-SIS2, compiles it as `liblm4.a` and links it to the FMS full coupler, replacing the land_null component.

The full model compilation has been tested on C6 with the following component versions:

GFDL_atmos_cubed_sphere `1ab589c`
FMS `33b8fbd1`
atmos_drivers `4ebbec2`
SHiELD_physics `79a3195`
FMSCoupler `37c09ac`
ice_param `1d19a57` 
LM4p `ab78f441 `
MOM6 `32849fa12`
SIS2 `933c404`
icebergs `8a346e4` 