### PR TITLE
modify module loads for hera and ursa

### DIFF
--- a/CHECKOUT_code
+++ b/CHECKOUT_code
@@ -82,8 +82,8 @@ release="main"
 
 fv3_release=$release
 phy_release=$release
-fms_release="2025.04"
-fms_c_release="2025.04"
+fms_release="2026.01"
+fms_c_release="2026.01"
 drivers_release=$release
 land_release="2025.04"
 

--- a/site/environment.intel.sh
+++ b/site/environment.intel.sh
@@ -165,10 +165,12 @@ case $hostname in
       echo " hera environment "
 
       source $MODULESHOME/init/sh
-      module load intel/15.1.133
-      module load netcdf/4.3.0
-      module load hdf5/1.8.14
-      module load cmake/3.20.1
+      module load gnu
+      module load intel/2023.2.0
+      module load impi/2023.2.0
+      module load netcdf/4.7.0
+      module load hdf5/1.14.5
+      module load cmake/3.28.1
 
       export LIBRARY_PATH="${LIBRARY_PATH}:${NETCDF}/lib:${HDF5}/lib"
       export NETCDF_DIR=${NETCDF}
@@ -176,7 +178,7 @@ case $hostname in
 
       # make your compiler selections here
       export FC=mpiifort
-      export CC=mpiicc
+      export CC=mpiicx
       export CXX=mpicpc
       export LD=mpiifort
       export TEMPLATE=site/intel.mk

--- a/site/environment.intel.sh
+++ b/site/environment.intel.sh
@@ -189,6 +189,35 @@ case $hostname in
       echo -e ' '
       module list
       ;;
+   u* )
+      echo " ursa environment "
+
+      source $MODULESHOME/init/sh
+      module load intel-oneapi-compilers/2025.3.1
+      module load intel-oneapi-mpi/2021.17.1
+      module load hdf5/1.14.3
+      module load netcdf-c/4.9.2
+      module load netcdf-fortran/4.6.1
+      module load cmake/3.30.2
+
+      export LIBRARY_PATH="${LIBRARY_PATH}:${NETCDF}/lib:${HDF5}/lib"
+      export NETCDF_DIR=${NETCDF}
+      export FMS_CPPDEFS=""
+      # Add -DHAVE_GETTID to the FMS cppDefs
+      export FMS_CPPDEFS=-DHAVE_GETTID
+
+      # make your compiler selections here
+      export FC=mpiifx
+      export CC=mpiicx
+      export CXX=mpicpc
+      export LD=mpiifx
+      export TEMPLATE=site/intel.mk
+      export LAUNCHER=srun
+
+      export AVX_LEVEL=-xHOST
+      echo -e ''
+      module list
+      ;;
    lsc* )
       echo " lsc environment "
 


### PR DESCRIPTION
**Description**

Hera module loads need to be updated.  I have updated to intel/2023.2.0.  I did try to update to intel/2024.2.1, but the mpi was not working - seems to be a hera installation issue, so I recommend using 2023.2.0

Ursa has been added to site/environment.intel.sh.  I have confirmed the SHiELD model builds.

Fixes # (issue)

**How Has This Been Tested?**

Compiled SHiELD on Hera
Compiled SHiELD on Ursa

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
