### PR TITLE
SerialBox Capabilities to Facilitate Pace Validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ sis2
 mom6
 lm4
 release
+serialbox

--- a/Build/BUILDserialbox
+++ b/Build/BUILDserialbox
@@ -66,7 +66,7 @@ if [ -z ${LIBS_DIR} ] ; then
 fi
 
 serialbox_dir=${LIBS_DIR}/serialbox/${compiler}
-\rm -rf $serialbox_dir
+rm -rf $serialbox_dir
 mkdir -p $serialbox_dir
 cd $serialbox_dir
 
@@ -89,18 +89,6 @@ if [ ${compiler} = 'intel' ] ; then
         source /opt/intel/oneapi/setvars.sh --force --oneapi-version 2025.2
 
         rm -rf CMakeCache.txt CMakeFiles
-
-        #cmake ../ \
-        #  -DCMAKE_INSTALL_PREFIX=install \
-        #  -DCMAKE_C_COMPILER=icx \
-        #  -DCMAKE_CXX_COMPILER=icpx \
-        #  -DCMAKE_Fortran_COMPILER=ifx \
-        #  -DCMAKE_Fortran_COMPILER_WORKS=ON \
-        #  -DSERIALBOX_ENABLE_FORTRAN=ON \
-        #  -DSERIALBOX_EXAMPLES=OFF \
-        #  -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-        #  -DCMAKE_VERBOSE_MAKEFILE=ON \
-        #  -DCMAKE_CXX_STANDARD=17
 
         cmake ../ \
           -DCMAKE_INSTALL_PREFIX=install \

--- a/Build/BUILDserialbox
+++ b/Build/BUILDserialbox
@@ -107,7 +107,12 @@ if [ ${compiler} = 'intel' ] ; then
     )
 else # ${compiler} = 'gnu'
   export FC=gfortran
-  cmake ../ -DSERIALBOX_ENABLE_FORTRAN=ON -DSERIALBOX_EXAMPLES=OFF
+
+  cmake ../ \
+    -DSERIALBOX_ENABLE_FORTRAN=ON \
+    -DSERIALBOX_EXAMPLES=OFF \
+    -DCMAKE_INSTALL_PREFIX=install \
+
   make
   make install
 fi

--- a/Build/BUILDserialbox
+++ b/Build/BUILDserialbox
@@ -1,0 +1,125 @@
+#!/bin/bash
+#***********************************************************************
+#*                   GNU Lesser General Public License
+#*
+#* This file is part of the SHiELD Build System.
+#*
+#* The SHiELD Build System free software: you can redistribute it
+#* and/or modify it under the terms of the
+#* GNU Lesser General Public License as published by the
+#* Free Software Foundation, either version 3 of the License, or
+#* (at your option) any later version.
+#*
+#* The SHiELD Build System distributed in the hope that it will be
+#* useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+#* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#* See the GNU General Public License for more details.
+#*
+#* You should have received a copy of the GNU Lesser General Public
+#* License along with theSHiELD Build System
+#* If not, see <http://www.gnu.org/licenses/>.
+#***********************************************************************
+#
+#  DISCLAIMER: This script is provided as-is and as such is unsupported.
+#
+
+set -x
+
+# set default values
+compiler="intel"
+
+#define versions to checkout
+version_serialbox="v2.6.2"
+
+# parse arguments
+  for arg in "$@"
+  do
+      case $arg in
+          intel|gnu)
+             compiler="${arg#*=}"
+             shift # Remove "compiler" from processing
+             ;;
+          *)
+          if [ ${arg#} != '--help' ] && [ ${arg#} != '-h' ] ; then
+            echo "option "${arg#}" not found"
+          fi
+          echo -e ' '
+          echo -e "valid options are:"
+          echo -e "\t[intel(D) | gnu ] \t\t\t compiler"
+          echo -e "\n"
+          exit
+          ;;
+      esac
+  done
+
+# set up some default variables if not called from COMPILE
+# LIBS_DIR is set if this script is called from the COMPILE script
+# EXTERNAL_LIBS is set if using external location for storage of nceplibs
+if [ -z ${LIBS_DIR} ] ; then
+   BUILD_ROOT=${PWD%/*}
+   LIBS_DIR=${BUILD_ROOT}/Build
+   if [ ! -z ${EXTERNAL_LIBS} ] ; then
+   LIBS_DIR=${EXTERNAL_LIBS}
+   fi
+   # load the proper environment for your machine
+   . ${BUILD_ROOT}/site/environment.${compiler}.sh
+fi
+
+serialbox_dir=${LIBS_DIR}/serialbox/${compiler}
+\rm -rf $serialbox_dir
+mkdir -p $serialbox_dir
+cd $serialbox_dir
+
+
+git clone -b $version_serialbox https://github.com/eth-cscs/serialbox2.git
+cd serialbox2
+mkdir build
+cd build
+
+# TODO: Make this better. For now, I'm putting in what I tried from my notes...
+
+if [ ${compiler} = 'intel' ] ; then
+
+    # Start temporary environment block. There seems to be a mismatch between the SHiELD_build environment
+    # variables and what's needed to build SerialBox.
+    (
+        # Switch INTEL_COMPILER_TYPE from CLASSIC to ONEAPI
+        export INTEL_COMPILER_TYPE=ONEAPI
+
+        source /opt/intel/oneapi/setvars.sh --force --oneapi-version 2025.2
+
+        rm -rf CMakeCache.txt CMakeFiles
+
+        #cmake ../ \
+        #  -DCMAKE_INSTALL_PREFIX=install \
+        #  -DCMAKE_C_COMPILER=icx \
+        #  -DCMAKE_CXX_COMPILER=icpx \
+        #  -DCMAKE_Fortran_COMPILER=ifx \
+        #  -DCMAKE_Fortran_COMPILER_WORKS=ON \
+        #  -DSERIALBOX_ENABLE_FORTRAN=ON \
+        #  -DSERIALBOX_EXAMPLES=OFF \
+        #  -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+        #  -DCMAKE_VERBOSE_MAKEFILE=ON \
+        #  -DCMAKE_CXX_STANDARD=17
+
+        cmake ../ \
+          -DCMAKE_INSTALL_PREFIX=install \
+          -DCMAKE_C_COMPILER=cc \
+          -DCMAKE_CXX_COMPILER=CC \
+          -DCMAKE_Fortran_COMPILER=ftn \
+          -DCMAKE_Fortran_COMPILER_WORKS=ON \
+          -DSERIALBOX_ENABLE_FORTRAN=ON \
+          -DSERIALBOX_EXAMPLES=OFF \
+          -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+          -DCMAKE_VERBOSE_MAKEFILE=ON \
+          -DCMAKE_CXX_STANDARD=14 \
+
+        cmake --build .
+        cmake --build . --target install
+    )
+else # ${compiler} = 'gnu'
+  export FC=gfortran
+  cmake ../ -DSERIALBOX_ENABLE_FORTRAN=ON -DSERIALBOX_EXAMPLES=OFF
+  make
+  make install
+fi

--- a/Build/COMPILE
+++ b/Build/COMPILE
@@ -55,6 +55,7 @@ spin()
   avx="Y"
   compiler="intel"
   clean="noclean"
+  serial="noserial"
   pic="nopic"
 
   config_name="SHiELD"
@@ -111,6 +112,10 @@ spin()
              clean="${arg#*=}"
              shift # Remove "clean" from processing
              ;;
+          noserial|serial)
+             serial="${arg#*=}"
+             shift # Remove "serial" from processing
+             ;;
           nopic|pic)
              pic="${arg#*=}"
              shift # Remove "pic" from processing
@@ -128,6 +133,7 @@ spin()
           echo -e "\t[avx(D) | noavx] \t\t\t use AVX_LEVEL defined in site/environment.<compiler>.sh"
           echo -e "\t[intel(D) | gnu | nvhpc] \t\t\t compiler"
           echo -e "\t[noclean(D) | clean | cleanall] \t cleans exec area"
+          echo -e "\t[noserial(D) | serial] \t\t\t SerialBox support (for Pace validation/comparison)"
           echo -e "\t[nopic(D) | pic] \t whether to build all components with the -fPIC flag (position independent code)"
           echo -e "\n"
           exit
@@ -158,6 +164,14 @@ export SHiELD_SRC=${PWD%/*/*}/SHiELD_SRC/
 export PATH="${BUILD_ROOT}/mkmf/bin:${BUILD_ROOT}/Build/mk_scripts:${PATH}"
 export LIBS_DIR=${BUILD_ROOT}/Build
 
+export SERIALBOX_ROOT=${LIBS_DIR}/serialbox/${compiler}/serialbox2/build/install
+export PP_SER=${SERIALBOX_ROOT}/python/pp_ser/pp_ser.py
+export PPSER_FLAGS="--verbose --ignore-identical -m utils_ppser_kbuff"
+export SHiELD_SRC_SER=${PWD%/*/*}/SHiELD_SRC_SER
+
+echo SHiELD_SRC=${SHiELD_SRC}
+echo SHiELD_SRC_SER=${SHiELD_SRC_SER}
+
 #
 # load the proper environment for your machine
 . ${BUILD_ROOT}/site/environment.${compiler}.sh
@@ -173,6 +187,7 @@ echo -e "\tbit      = $bit"
 echo -e "\tavx      = $avx"
 echo -e "\tcompiler = $compiler"
 echo -e "\tclean    = $clean"
+echo -e "\tserial   = $serial"
 echo -e "\tpic      = $pic"
 echo -e "\n"
 sleep 5
@@ -206,6 +221,8 @@ fi
      \rm -rf mom6/${comp}.${bit}.${compiler}/*
      \rm -rf sis2/${comp}.${bit}.${compiler}/*
      \rm -rf lm4/${comp}.${bit}.${compiler}/*
+     \rm -rf serialbox/${compiler}/*
+     \rm -rf ${SHiELD_SRC_SER}/*
   elif [ ${clean} = "clean" ] ; then
      echo " cleaning build directory in 2 seconds"
      sleep 2
@@ -213,6 +230,8 @@ fi
      \rm -rf lm4/${comp}.${bit}.${compiler}/*
      \rm -rf sis2/${comp}.${bit}.${compiler}/*
      \rm -rf exec/${config}_${hydro}.${comp}.${bit}.${compiler}/*
+     \rm -rf serialbox/${compiler}/*
+     \rm -rf ${SHiELD_SRC_SER}/*
   fi
 
 # If EXTERNAL_LIBS is set, then the program will use the path defined by
@@ -246,6 +265,19 @@ fi
         echo ">>> ${LIBS_DIR}/ncepdir/${compiler} build failed"
         exit 3
      fi
+  fi
+# check to make sure serialbox exists
+  if [ -d ${LIBS_DIR}/serialbox/${compiler} ] && [ -d ${LIBS_DIR}/serialbox/${compiler}/serialbox2/build/install ] && \
+     [ -e ${LIBS_DIR}/serialbox/${compiler}/serialbox2/build/install/lib/libSerialboxFortran.so.2.6.2 ] && \
+     [ -e ${LIBS_DIR}/serialbox/${compiler}/serialbox2/build/install/python/pp_ser/pp_ser.py ] ; then
+      echo " pre-built ${LIBS_DIR}/serialbox/${compiler} exists"
+  else
+      echo " ${LIBS_DIR}/serialbox/${compiler} does not exist"
+      ./BUILDserialbox ${compiler}
+      if [ $? -ne 0 ] ; then
+         echo ">>> ${LIBS_DIR}/serialbox/${compiler} build failed"
+         exit 2
+      fi
   fi
 
 if [ $config = "shiemom" ] || [ $config = "shiemom_lm4" ]  ; then
@@ -297,8 +329,39 @@ fi
   mkdir -p ./exec/${config}_${hydro}.${comp}.${bit}.${compiler}
   mkdir -p ./bin/
 
+#
+# optionally run serialbox preprocessor and update SHiELD_SRC to SHiELD_SRC_SER
+  if [ $serial = "serial" ] ; then
+    echo -e ">>> preprocessing code for serialization"
+    echo SHiELD_SRC=${SHiELD_SRC}
+    echo SHiELD_SRC_SER=${SHiELD_SRC_SER}
+
+    mkdir -p ${SHiELD_SRC_SER}
+    rsync -a --log-file=/ncrc/home1/Janice.Kim/work/20260129_translate_tests/PRs/serialbox_src_rsync.log ${SHiELD_SRC} ${SHiELD_SRC_SER}
+
+    # Run preprocessor on SHiELD_SRC *.F90 and *.F files and write the output to SHiELD_SRC_SER
+    find "${SHiELD_SRC}" -type f \( -name "*.F90" -o -name "*.F" \) -printf "%P\n" | while read -r rel; do
+	infile=${SHiELD_SRC}/${rel}
+	outfile=${SHiELD_SRC_SER}/${rel}
+
+	rm ${outfile}
+	echo "Removing ${outfile}"
+	echo "command: python3 $PP_SER $PPSER_FLAGS ${infile} -o ${outfile}"
+
+	if ! python3 $PP_SER $PPSER_FLAGS "${infile}" -o "${outfile}"; then
+	    echo "PP_SER failed on $rel. Copying unmodified version instead."
+	    cp "${infile}" "${outfile}"
+	fi
+    done
+
+    # Change the SHiELD_SRC to the SerialBox-preprocessed code
+    export SHiELD_SRC=${SHiELD_SRC_SER}
+    echo -e "${SHiELD_SRC} is now ${SHiELD_SRC_SER}"
+    echo -e "Finished preprocessing for serialization"
+  fi
+
 # build the model
-echo -e "  building ${config} ${hydro} ${comp} ${bit} ${compiler} \t `date`"
+echo -e "  building ${config} ${hydro} ${comp} ${bit} ${compiler} ${serial} \t `date`"
   #
   # create the file list for the build
     mk_paths ${config} ${hydro} ${comp} ${bit} ${compiler}       > build_${config}_${hydro}.${comp}.${bit}.${compiler}.out 2>&1
@@ -308,7 +371,7 @@ echo -e "  building ${config} ${hydro} ${comp} ${bit} ${compiler} \t `date`"
     fi
   #
   # create the library makefiles
-    mk_makefile ${config} ${hydro} ${comp} ${bit} ${compiler}    >> build_${config}_${hydro}.${comp}.${bit}.${compiler}.out 2>&1
+    mk_makefile ${config} ${hydro} ${comp} ${bit} ${compiler} ${serial}    >> build_${config}_${hydro}.${comp}.${bit}.${compiler}.out 2>&1
     if [ $? -ne 0 ] ; then
        echo ">>> makefile creation failed"
        exit 5
@@ -323,10 +386,10 @@ echo -e "  building ${config} ${hydro} ${comp} ${bit} ${compiler} \t `date`"
 #
 # test and report on build success
   if [ $? -ne 0 ] ; then
-     echo ">>> ${config_name} build ${hydro} ${comp} ${bit} ${compiler} failed"
+     echo ">>> ${config_name} build ${hydro} ${comp} ${bit} ${compiler} ${serial} failed"
      exit 6
   else
-     echo " ${config_name} build ${hydro} ${comp} ${bit} ${compiler} successful"
+     echo " ${config_name} build ${hydro} ${comp} ${bit} ${compiler} ${serial} successful"
   fi
 
 exit 0

--- a/Build/COMPILE
+++ b/Build/COMPILE
@@ -169,8 +169,6 @@ export PP_SER=${SERIALBOX_ROOT}/python/pp_ser/pp_ser.py
 export PPSER_FLAGS="--verbose --ignore-identical -m utils_ppser_kbuff"
 export SHiELD_SRC_SER=${PWD%/*/*}/SHiELD_SRC_SER
 
-echo SHiELD_SRC=${SHiELD_SRC}
-echo SHiELD_SRC_SER=${SHiELD_SRC_SER}
 
 #
 # load the proper environment for your machine
@@ -266,7 +264,9 @@ fi
         exit 3
      fi
   fi
+
 # check to make sure serialbox exists
+if [ $serial = "serial" ] ; then
   if [ -d ${LIBS_DIR}/serialbox/${compiler} ] && [ -d ${LIBS_DIR}/serialbox/${compiler}/serialbox2/build/install ] && \
      [ -e ${LIBS_DIR}/serialbox/${compiler}/serialbox2/build/install/lib/libSerialboxFortran.so.2.6.2 ] && \
      [ -e ${LIBS_DIR}/serialbox/${compiler}/serialbox2/build/install/python/pp_ser/pp_ser.py ] ; then
@@ -279,6 +279,7 @@ fi
          exit 2
       fi
   fi
+fi
 
 if [ $config = "shiemom" ] || [ $config = "shiemom_lm4" ]  ; then
 # from lauren
@@ -334,26 +335,26 @@ fi
 # and update SHiELD_SRC to SHiELD_SRC_SER
   if [ $serial = "serial" ] ; then
     echo -e ">>> preprocessing code for serialization"
-    echo SHiELD_SRC=${SHiELD_SRC}
-    echo SHiELD_SRC_SER=${SHiELD_SRC_SER}
 
     mkdir -p ${SHiELD_SRC_SER}
     rsync -a --log-file=serialbox_src_rsync.out ${SHiELD_SRC} ${SHiELD_SRC_SER}
 
     # Run preprocessor on SHiELD_SRC *.F90 and *.F files and write the output to SHiELD_SRC_SER
-    find "${SHiELD_SRC}" -type f \( -name "*.F90" -o -name "*.F" \) -printf "%P\n" | while read -r rel; do
-	infile=${SHiELD_SRC}/${rel}
-	outfile=${SHiELD_SRC_SER}/${rel}
+    find "${SHiELD_SRC}" -type f \( -name "*.F90" -o -name "*.F" \) -printf "%P\n" | while read -r rel
+    do
+        infile=${SHiELD_SRC}/${rel}
+        outfile=${SHiELD_SRC_SER}/${rel}
 
-	# NOTE: I can't get PP_SER to work properly without deleting the file first.
-	echo "Removing ${outfile}"
-	rm ${outfile}
+        echo "Processing ${rel}"
+
+        # NOTE: I can't get PP_SER to work properly without deleting the file first.
+        rm ${outfile}
 	
-	echo "command: python3 $PP_SER $PPSER_FLAGS ${infile} -o ${outfile}"
-	if ! python3 $PP_SER $PPSER_FLAGS "${infile}" -o "${outfile}"; then
-	    echo "PP_SER failed on $rel. Copying unmodified version instead."
-	    cp "${infile}" "${outfile}"
-	fi
+        echo "command: python3 ${PP_SER} ${PPSER_FLAGS} ${infile} -o ${outfile}"
+        if ! python3 ${PP_SER} ${PPSER_FLAGS} "${infile}" -o "${outfile}" ; then
+            echo "PP_SER failed on ${rel}. Copying unmodified version instead."
+            cp "${infile}"  "${outfile}"
+        fi
     done
 
     # Change the SHiELD_SRC to the SerialBox-preprocessed code

--- a/Build/COMPILE
+++ b/Build/COMPILE
@@ -330,24 +330,26 @@ fi
   mkdir -p ./bin/
 
 #
-# optionally run serialbox preprocessor and update SHiELD_SRC to SHiELD_SRC_SER
+# optionally run serialbox preprocessor on a new source code tree
+# and update SHiELD_SRC to SHiELD_SRC_SER
   if [ $serial = "serial" ] ; then
     echo -e ">>> preprocessing code for serialization"
     echo SHiELD_SRC=${SHiELD_SRC}
     echo SHiELD_SRC_SER=${SHiELD_SRC_SER}
 
     mkdir -p ${SHiELD_SRC_SER}
-    rsync -a --log-file=/ncrc/home1/Janice.Kim/work/20260129_translate_tests/PRs/serialbox_src_rsync.log ${SHiELD_SRC} ${SHiELD_SRC_SER}
+    rsync -a --log-file=serialbox_src_rsync.out ${SHiELD_SRC} ${SHiELD_SRC_SER}
 
     # Run preprocessor on SHiELD_SRC *.F90 and *.F files and write the output to SHiELD_SRC_SER
     find "${SHiELD_SRC}" -type f \( -name "*.F90" -o -name "*.F" \) -printf "%P\n" | while read -r rel; do
 	infile=${SHiELD_SRC}/${rel}
 	outfile=${SHiELD_SRC_SER}/${rel}
 
-	rm ${outfile}
+	# NOTE: I can't get PP_SER to work properly without deleting the file first.
 	echo "Removing ${outfile}"
+	rm ${outfile}
+	
 	echo "command: python3 $PP_SER $PPSER_FLAGS ${infile} -o ${outfile}"
-
 	if ! python3 $PP_SER $PPSER_FLAGS "${infile}" -o "${outfile}"; then
 	    echo "PP_SER failed on $rel. Copying unmodified version instead."
 	    cp "${infile}" "${outfile}"
@@ -356,7 +358,7 @@ fi
 
     # Change the SHiELD_SRC to the SerialBox-preprocessed code
     export SHiELD_SRC=${SHiELD_SRC_SER}
-    echo -e "${SHiELD_SRC} is now ${SHiELD_SRC_SER}"
+    echo -e "SHiELD_SRC is now pointing at ${SHiELD_SRC_SER}"
     echo -e "Finished preprocessing for serialization"
   fi
 
@@ -371,14 +373,14 @@ echo -e "  building ${config} ${hydro} ${comp} ${bit} ${compiler} ${serial} \t `
     fi
   #
   # create the library makefiles
-    mk_makefile ${config} ${hydro} ${comp} ${bit} ${compiler} ${serial}    >> build_${config}_${hydro}.${comp}.${bit}.${compiler}.out 2>&1
+    mk_makefile ${config} ${hydro} ${comp} ${bit} ${compiler}    >> build_${config}_${hydro}.${comp}.${bit}.${compiler}.out 2>&1
     if [ $? -ne 0 ] ; then
        echo ">>> makefile creation failed"
        exit 5
     fi
   #
   # build the configuration
-    mk_make ${config} ${hydro} ${comp} ${bit} ${avx} ${compiler} ${pic} >> build_${config}_${hydro}.${comp}.${bit}.${compiler}.out 2>&1
+    mk_make ${config} ${hydro} ${comp} ${bit} ${avx} ${compiler} ${pic} ${serial} >> build_${config}_${hydro}.${comp}.${bit}.${compiler}.out 2>&1
   #
   # move the executable to an accessible area
     mv exec/${config}_${hydro}.${comp}.${bit}.${compiler}/test.x bin/${config_name}_${hydro}.${comp}.${bit}.${compiler}.x

--- a/Build/mk_scripts/mk_make
+++ b/Build/mk_scripts/mk_make
@@ -35,6 +35,7 @@ COMPILER="intel"
 bit="32bit"
 comp="prod"
 pic="nopic"
+serial="noserial"
 
 #
 ## parse arguments
@@ -81,6 +82,14 @@ do
           fi
           shift # Remove PIC from processing
           ;;
+        noserial|serial)
+          if [ "${arg#*=}" = 'serial' ] ; then
+            SERIAL=Y
+          else
+            SERIAL=N
+          fi
+          shift # Remove SERIAL from processing
+          ;;
     esac
 done
 
@@ -114,12 +123,12 @@ elif [ ${CONFIG} = 'shiemom_lm4'  ] ; then
 fi
 
 if [ ${CONFIG} = 'shield' ] || [ ${CONFIG} = 'shiemom' ] ||  [ ${CONFIG} = 'shiemom_lm4' ]   ; then
-  (cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y ${COMP} AVX=${AVX} PIC=${PIC} -f Makefile_gfs)
+  (cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y ${COMP} AVX=${AVX} PIC=${PIC} SERIAL=${SERIAL} -f Makefile_gfs)
 fi
 
-(cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y NETCDF=3 ${COMP} AVX=${AVX} ${BIT} PIC=${PIC} EXTERNALLIBS="${EXTERNALLIBS}" -f Makefile_fv3)
+(cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y NETCDF=3 ${COMP} AVX=${AVX} ${BIT} PIC=${PIC} SERIAL=${SERIAL} EXTERNALLIBS="${EXTERNALLIBS}" -f Makefile_fv3)
 
 if   [ ${CONFIG} = 'shield' ] || [ ${CONFIG} = 'shiemom' ] || [ ${CONFIG} = 'shiemom_lm4' ]  ; then
-   (cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y NETCDF=3 ${COMP} AVX=${AVX} PIC=${PIC} EXTERNALLIBS="${EXTERNALLIBS}" -f Makefile_driver)
+   (cd exec/${CONFIG}_${HYDRO}.${comp}.${bit}.${COMPILER} ; make -j 8 OPENMP=Y NETCDF=3 ${COMP} AVX=${AVX} PIC=${PIC} SERIAL=${SERIAL} EXTERNALLIBS="${EXTERNALLIBS}" -f Makefile_driver)
 fi
 exit 0

--- a/Build/mk_scripts/mk_makefile
+++ b/Build/mk_scripts/mk_makefile
@@ -30,7 +30,6 @@ HYDRO="nh"
 COMP="prod"
 BIT="32bit"
 COMPILER="intel"
-SERIAL="noserial"
 
 #
 ### parse arguments
@@ -57,10 +56,6 @@ do
         COMPILER="${arg#*=}"
         shift # Remove compiler from processing
         ;;
-        noserial|serial)
-        SERIAL="${arg#*=}"
-        shift # Remove serial from processing
-        ;;
     esac
 done
 
@@ -69,10 +64,6 @@ set -x
 #
 # GFS CPPDEFS
 GFS_cppDefs="-DNEW_TAUCTMAX -DNEMS_GSM -DINTERNAL_FILE_NML"
-# optionally add serialization
-if [ ${SERIAL} = 'serial' ] ; then
-    GFS_cppDefs+=" -DSERIALIZE"
-fi
 
 #
 # FV3 CPPDEFS
@@ -85,10 +76,6 @@ elif [ ${CONFIG} = 'shiemom_lm4' ] ; then
 elif [ ${CONFIG} = 'solo' ] ; then
   FV3_cppDefs+=" -DDCMIP -DDYCORE_SOLO -DHIWPP"
 fi
-# optionally add serialization
-if [ ${SERIAL} = 'serial' ] ; then
-    FV3_cppDefs+=" -DSERIALIZE"
-fi
 
 #
 # add non-hydrostatic or shallow-water CPPDEFS
@@ -98,27 +85,18 @@ elif [ ${HYDRO} = 'sw' ] ; then
   FV3_cppDefs+=" -DSW_DYNAMICS -DDYNAMICS_ZS"
 fi
 
-#
-# optionally link serialbox modules for data serialization
-SERIAL_I_FLAGS=""
-SERIAL_L_FLAGS=""
-if [ ${SERIAL} = 'serial' ] ; then
-  SERIAL_I_FLAGS+="-I${SERIALBOX_ROOT}/include"
-  SERIAL_L_FLAGS+="-L${SERIALBOX_ROOT}/lib -lSerialboxFortran -lSerialboxC -lSerialboxCore"
-fi
-
 pushd exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/
 
 ############################
 #---CREATE MAKEFILES
 ############################
 if [ ${CONFIG} = 'shield' ]  ; then
-   mkmf -m Makefile_gfs -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" ${SERIAL_I_FLAGS} -o "-cpp" -c "${GFS_cppDefs}" \
-           -p libgfs.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_gfs ${SERIAL_L_FLAGS}
+   mkmf -m Makefile_gfs -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -o "-cpp" -c "${GFS_cppDefs}" \
+           -p libgfs.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_gfs
 
-   mkmf -m Makefile_fv3 -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" ${SERIAL_I_FLAGS} \
+   mkmf -m Makefile_fv3 -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" \
              -o "-I${SHiELD_SRC}/FMS/include -I${SHiELD_SRC}/GFDL_atmos_cubed_sphere/driver/SHiELD/include -I${LIBS_DIR}/libFMS/${COMPILER}/64bit" -c "${FV3_cppDefs}" \
-             -p libfv3.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3 ${SERIAL_L_FLAGS}
+             -p libfv3.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3
    mkmf -m Makefile_driver -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "${FV3_cppDefs}" \
              -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${LIBS_DIR}/libFMS/${COMPILER}/64bit" \
              ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver
@@ -132,7 +110,7 @@ elif [ ${CONFIG} = 'shiemom' ]; then
            -p libfv3.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3
 
   mkmf -m Makefile_driver -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "${FV3_cppDefs}" \
-           -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${LIBS_DIR}/libFMS/${COMPILER}/64bit -I${LIBS_DIR}/mom6/${COMPILER} -I${LIBS_DIR}/sis2/${COMPILER}" \
+           -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${LIBS_DIR}/libFMS/${COMPILER}/64bit -I${LIBS_DIR}/mom6/${COMP}.64bit.${COMPILER} -I${LIBS_DIR}/sis2/${COMP}.64bit.${COMPILER}" \
            ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver
 
 elif [ ${CONFIG} = 'shiemom_lm4' ]; then
@@ -144,14 +122,14 @@ elif [ ${CONFIG} = 'shiemom_lm4' ]; then
            -p libfv3.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3
 
   mkmf -m Makefile_driver -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "${FV3_cppDefs}" \
-           -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${LIBS_DIR}/libFMS/${COMPILER}/64bit -I${LIBS_DIR}/mom6/${COMPILER} -I${LIBS_DIR}/sis2/${COMPILER} -I${LIBS_DIR}/lm4/${COMPILER}" \
+           -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${LIBS_DIR}/libFMS/${COMPILER}/64bit -I${LIBS_DIR}/mom6/${COMP}.64bit.${COMPILER} -I${LIBS_DIR}/sis2/${COMP}.64bit.${COMPILER} -I${LIBS_DIR}/lm4/${COMP}.64bit.${COMPILER}" \
            ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver
 
 
 elif [ ${CONFIG} = 'solo' ] ; then
-  mkmf -m Makefile_fv3 -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" ${SERIAL_I_FLAGS} -c "${FV3_cppDefs}" \
+  mkmf -m Makefile_fv3 -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "${FV3_cppDefs}" \
           -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${LIBS_DIR}/libFMS/${COMPILER}/${BIT}" \
-            ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3 ${SERIAL_L_FLAGS}
+            ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3
 fi
 
 ############################

--- a/Build/mk_scripts/mk_makefile
+++ b/Build/mk_scripts/mk_makefile
@@ -30,6 +30,7 @@ HYDRO="nh"
 COMP="prod"
 BIT="32bit"
 COMPILER="intel"
+SERIAL="noserial"
 
 #
 ### parse arguments
@@ -56,6 +57,10 @@ do
         COMPILER="${arg#*=}"
         shift # Remove compiler from processing
         ;;
+        noserial|serial)
+        SERIAL="${arg#*=}"
+        shift # Remove serial from processing
+        ;;
     esac
 done
 
@@ -64,6 +69,10 @@ set -x
 #
 # GFS CPPDEFS
 GFS_cppDefs="-DNEW_TAUCTMAX -DNEMS_GSM -DINTERNAL_FILE_NML"
+# optionally add serialization
+if [ ${SERIAL} = 'serial' ] ; then
+    GFS_cppDefs+=" -DSERIALIZE"
+fi
 
 #
 # FV3 CPPDEFS
@@ -76,6 +85,10 @@ elif [ ${CONFIG} = 'shiemom_lm4' ] ; then
 elif [ ${CONFIG} = 'solo' ] ; then
   FV3_cppDefs+=" -DDCMIP -DDYCORE_SOLO -DHIWPP"
 fi
+# optionally add serialization
+if [ ${SERIAL} = 'serial' ] ; then
+    FV3_cppDefs+=" -DSERIALIZE"
+fi
 
 #
 # add non-hydrostatic or shallow-water CPPDEFS
@@ -85,18 +98,27 @@ elif [ ${HYDRO} = 'sw' ] ; then
   FV3_cppDefs+=" -DSW_DYNAMICS -DDYNAMICS_ZS"
 fi
 
+#
+# optionally link serialbox modules for data serialization
+SERIAL_I_FLAGS=""
+SERIAL_L_FLAGS=""
+if [ ${SERIAL} = 'serial' ] ; then
+  SERIAL_I_FLAGS+="-I${SERIALBOX_ROOT}/include"
+  SERIAL_L_FLAGS+="-L${SERIALBOX_ROOT}/lib -lSerialboxFortran -lSerialboxC -lSerialboxCore"
+fi
+
 pushd exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/
 
 ############################
 #---CREATE MAKEFILES
 ############################
 if [ ${CONFIG} = 'shield' ]  ; then
-   mkmf -m Makefile_gfs -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -o "-cpp" -c "${GFS_cppDefs}" \
-           -p libgfs.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_gfs
+   mkmf -m Makefile_gfs -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" ${SERIAL_I_FLAGS} -o "-cpp" -c "${GFS_cppDefs}" \
+           -p libgfs.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_gfs ${SERIAL_L_FLAGS}
 
-   mkmf -m Makefile_fv3 -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" \
+   mkmf -m Makefile_fv3 -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" ${SERIAL_I_FLAGS} \
              -o "-I${SHiELD_SRC}/FMS/include -I${SHiELD_SRC}/GFDL_atmos_cubed_sphere/driver/SHiELD/include -I${LIBS_DIR}/libFMS/${COMPILER}/64bit" -c "${FV3_cppDefs}" \
-             -p libfv3.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3
+             -p libfv3.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3 ${SERIAL_L_FLAGS}
    mkmf -m Makefile_driver -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "${FV3_cppDefs}" \
              -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${LIBS_DIR}/libFMS/${COMPILER}/64bit" \
              ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver
@@ -110,7 +132,7 @@ elif [ ${CONFIG} = 'shiemom' ]; then
            -p libfv3.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3
 
   mkmf -m Makefile_driver -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "${FV3_cppDefs}" \
-           -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${LIBS_DIR}/libFMS/${COMPILER}/64bit -I${LIBS_DIR}/mom6/${COMP}.64bit.${COMPILER} -I${LIBS_DIR}/sis2/${COMP}.64bit.${COMPILER}" \
+           -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${LIBS_DIR}/libFMS/${COMPILER}/64bit -I${LIBS_DIR}/mom6/${COMPILER} -I${LIBS_DIR}/sis2/${COMPILER}" \
            ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver
 
 elif [ ${CONFIG} = 'shiemom_lm4' ]; then
@@ -122,14 +144,14 @@ elif [ ${CONFIG} = 'shiemom_lm4' ]; then
            -p libfv3.a ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3
 
   mkmf -m Makefile_driver -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "${FV3_cppDefs}" \
-           -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${LIBS_DIR}/libFMS/${COMPILER}/64bit -I${LIBS_DIR}/mom6/${COMP}.64bit.${COMPILER} -I${LIBS_DIR}/sis2/${COMP}.64bit.${COMPILER} -I${LIBS_DIR}/lm4/${COMP}.64bit.${COMPILER}" \
+           -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${LIBS_DIR}/libFMS/${COMPILER}/64bit -I${LIBS_DIR}/mom6/${COMPILER} -I${LIBS_DIR}/sis2/${COMPILER} -I${LIBS_DIR}/lm4/${COMPILER}" \
            ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_driver
 
 
 elif [ ${CONFIG} = 'solo' ] ; then
-  mkmf -m Makefile_fv3 -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" -c "${FV3_cppDefs}" \
+  mkmf -m Makefile_fv3 -a ${SHiELD_SRC} -t "${BUILD_ROOT}/${TEMPLATE}" ${SERIAL_I_FLAGS} -c "${FV3_cppDefs}" \
           -p test.x -o "-I${SHiELD_SRC}/FMS/include -I${LIBS_DIR}/libFMS/${COMPILER}/${BIT}" \
-            ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3
+            ${BUILD_ROOT}/Build/exec/${CONFIG}_${HYDRO}.${COMP}.${BIT}.${COMPILER}/pathnames_fv3 ${SERIAL_L_FLAGS}
 fi
 
 ############################

--- a/RTS/GAEA_RTS/serialbox/C48_res.aquaplanet.csh
+++ b/RTS/GAEA_RTS/serialbox/C48_res.aquaplanet.csh
@@ -1,0 +1,767 @@
+#!/bin/tcsh
+#SBATCH --output=./stdout/%x.%j
+#SBATCH --job-name=C48_res_aquaplanet
+#SBATCH --clusters=c5
+#SBATCH --time=00:60:00
+#SBATCH --nodes=3
+
+# see run_tests.sh for an example of how to run these tests
+
+set echo
+
+set YourGroup  = "gfdl_f" #modify this to be your own group on f5
+set BASEDIR    = "/gpfs/f5/${YourGroup}/scratch/${USER}/"
+set INPUT_DATA = "/gpfs/f5/gfdl_w/proj-shared/fvGFS_INPUT_DATA"
+#set BUILD_AREA = "/ncrc/home1/${USER}/SHiELD_dev/SHiELD_build/"
+set BUILD_AREA = "/ncrc/home1/${USER}/work/20260129_translate_tests/PRs/SHiELD_build"
+
+if ( ! $?COMPILER ) then
+  set COMPILER = "intel"
+endif
+
+set RELEASE = "`cat ${BUILD_AREA}/../SHiELD_SRC/release`"
+
+set SERIALBOX_ROOT=${BUILD_AREA}/Build/serialbox/${COMPILER}/serialbox2/build/install
+set LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${SERIALBOX_ROOT}/lib
+echo $LD_LIBRARY_PATH
+
+source ${BUILD_AREA}/site/environment.${COMPILER}.csh
+
+#set hires_oro_factor = 3
+set res = 48
+
+set CPN = 40
+# case specific details
+set TYPE = "nh"         # choices:  nh, hydro
+if ( ! $?MODE ) then
+  set MODE = "32bit"      # choices:  32bit, 64bit
+endif
+set MONO = "non-mono"   # choices:  mono, non-mono
+set GRID = "C$res"
+set MEMO = "$SLURM_JOB_NAME" # trying prod executable
+set HYPT = "off"         # choices:  on, off  (controls hyperthreading)
+if ( ! $?COMP ) then
+  set COMP = "repro"       # choices:  debug, repro, prod
+endif
+set NO_SEND = "no_send"    # choices:  send, no_send  # send option not available yet
+set NUM_TOT = 4         # run cycle, 1: no restart 
+if (! $?DATE) then
+    set DATE=20160801.00Z
+else
+    echo $DATE
+endif
+set NAME = $DATE
+set CASE = "C$res"
+set EXE = "x"
+
+# directory structure
+set WORKDIR    = ${BASEDIR}/SHiELD_${RELEASE}/${NAME}.${CASE}.${TYPE}.${COMP}.${MODE}.${COMPILER}.${MONO}.${MEMO}/
+set executable = ${BUILD_AREA}/Build/bin/SHiELD_${TYPE}.${COMP}.${MODE}.${COMPILER}.${EXE}
+
+# sending file to gfdl
+#set gfdl_archive = /archive/${USER}/SHiELD_S2S/${NAME}.${CASE}.${TYPE}.${MODE}.${MEMO}/
+#set SEND_FILE = ~${USER}/Util/send_file_slurm.csh
+set TIME_STAMP = ${BUILD_AREA}/site/time_stamp.csh
+
+# input filesets
+set ICDIR   = ${INPUT_DATA}/global.v201810/${CASE}/${NAME}_IC/  #CHECK
+set ICS     = ${ICDIR}/GFS_INPUT.tar
+set FIXDIR  = ${INPUT_DATA}/fix.v201810/
+set CLIMO_DATA = ${INPUT_DATA}/climo_data.v201807/
+set GFS_STD_INPUT  = ${INPUT_DATA}/GFS_STD_INPUT.20160311.tar #This should remain a tarball
+set GRIDDIR = ${INPUT_DATA}/global.v201810/${CASE}/GRID/ #CHECK
+
+
+# changeable parameters
+    # dycore definitions
+    set npx = "49"
+    set npy = "49"
+    set npz = "79"
+    set layout_x = "1"
+    set layout_y = "1"
+    set io_layout = "1,1"
+    set nthreads = "4"
+
+    # blocking factor used for threading and general physics performance
+    set blocksize = "32"
+
+    # run length
+    set months = "0"
+    set days = "0"
+    set hours = "1"
+    set seconds = "0"
+    set dt_atmos = "450"
+
+    #fms yaml
+    set use_yaml=".F." #if True, requires data_table.yaml and field_table.yaml
+
+# variables for gfs diagnostic output intervals and time to zero out time-accumulated data
+#set fdiag = "6.,12.,18.,24.,30.,36.,42.,48.,54.,60.,66.,72.,78.,84.,90.,96.,102.,108.,114.,120.,126.,132.,138.,144.,150.,156.,162.,168.,174.,180.,186.,192.,198.,204.,210.,216.,222.,228.,234.,240."
+set fdiag = "3.0"
+set fhzer = "3.0"
+set fhcyc = "24."
+
+# determines whether FV3 or GFS physics calculate geopotential
+set gfs_phil = ".false." 
+
+# determine whether ozone production occurs in GFS physics                                         
+set ozcalc = ".true."                                                                              
+                                                                                                           
+# set various debug options                                                                        
+set no_dycore = ".false."                                                                          
+set dycore_only = ".false."                                                                        
+set chksum_debug = ".false."                                                                       
+set print_freq = "6"         
+
+if (${TYPE} == "nh") then
+  # non-hydrostatic options
+  set make_nh = ".T."
+  set hydrostatic = ".F."
+  set phys_hydrostatic = ".F."     # can be tested
+  set use_hydro_pressure = ".F."   # can be tested
+  set consv_te = "1."
+  set k_split = "1"
+  set n_split = "2"
+else
+  # hydrostatic options
+  set make_nh = ".F."
+  set hydrostatic = ".T."
+  set phys_hydrostatic = ".F."     # will be ignored in hydro mode
+  set use_hydro_pressure = ".T."   # have to be .T. in hydro mode
+  set consv_te = "0."
+  set k_split = "1"
+  set n_split = "2"
+endif
+
+if (${MONO} == "mono" || ${MONO} == "monotonic") then                                              
+  # monotonic options                                                                              
+  set d_con = "1."                                                                                 
+  set do_vort_damp = ".false."                                                                     
+else                                                                                               
+  # non-monotonic options                                                                          
+  set d_con = "1."                                                                                 
+  set do_vort_damp = ".true."                                                                      
+endif                                                                                              
+
+
+# variables for hyperthreading
+set cores_per_node = $CPN
+if (${HYPT} == "on") then
+  set hyperthread = ".true."
+  set j_opt = "-j2"
+  set div = 2
+else
+  set hyperthread = ".false."
+  set j_opt = "-j1"
+  set div = 1
+endif
+
+# when running with threads, need to use the following command
+    @ npes = ${layout_x} * ${layout_y} * 6
+    @ skip = ${nthreads} / ${div}
+    set run_cmd = "srun --ntasks=$npes --cpus-per-task=$skip ./$executable:t"
+
+    setenv MPICH_ENV_DISPLAY
+    setenv MPICH_MPIIO_CB_ALIGN 2
+    setenv MALLOC_TRIM_THRESHOLD_ 536870912
+    setenv NC_BLKSZ 1M
+# necessary for OpenMP when using Intel
+    setenv KMP_STACKSIZE 256m
+    setenv SLURM_CPU_BIND verbose
+
+
+set SCRIPT_AREA = $PWD
+#if ( "$PBS_JOBDATE" == "BATCH" | "$PBS_JOBNAME" == "STDIN" ) then
+if ( "$SLURM_JOB_NAME" == "sh" ) then
+  set SCRIPT = "${SCRIPT_AREA}/$0"
+else
+  set SCRIPT = "${SCRIPT_AREA}/$SLURM_JOB_NAME"
+endif
+#set RST_COUNT = ${SCRIPT}.rst.count
+mkdir -p $WORKDIR/restart
+set RST_COUNT = $WORKDIR/restart/rst.count
+#######DEBUG
+#\rm -f $RST_COUNT
+#######END DEBUG
+if ( -f ${RST_COUNT} ) then
+  source ${RST_COUNT}
+  #set num = `cat ${RST_COUNT} | tr -d -c '[0-9]'`
+  if ( x"$num" == "x" || ${num} < 1 ) then
+    set RESTART_RUN = "F"
+    echo " Restart = F"
+  else
+    set RESTART_RUN = "T"
+    echo " Restart = T"
+  endif
+else
+  set num = 0
+  set RESTART_RUN = "F"
+    echo " Restart = FF"
+endif
+
+#set RESTART_RUN = "F"
+
+#NEED TO BE CAREFUL OF SETUP CODE WRT RESTARTS!!
+if (${RESTART_RUN} == "F") then
+
+  \rm -rf $WORKDIR/rundir
+
+  mkdir -p $WORKDIR/rundir
+  cd $WORKDIR/rundir
+
+  mkdir -p RESTART
+  mkdir -p INPUT
+
+  # Date specific ICs
+  cp -rf ${ICDIR}/* INPUT/
+
+  # set variables in input.nml for initial run
+  set ecmwf_ic = ".F." 
+  set nggps_ic = ".T."
+  set mountain = ".F."
+  set external_ic = ".T."
+  set warm_start = ".F."
+  set na_init = 0
+
+else
+
+  cd $WORKDIR/rundir
+  \rm -rf INPUT/*
+
+  # move the restart data into INPUT/
+  #mv RESTART/* INPUT/.
+  cp -rf ${restart_dir}/coupler.res ${restart_dir}/[^0-9]*.nc ${restart_dir}/[^0-9]*.nc.???? INPUT/.
+
+  # reset values in input.nml for restart run
+  set make_nh = ".F."
+  set nggps_ic = ".F."
+  set ecmwf_ic = ".F."
+  set mountain = ".T."
+  set external_ic = ".F."
+  set warm_start = ".T."
+  set na_init = 0
+
+endif
+ls INPUT/
+ls RESTART/
+
+# copy over the other tables and executable
+if ( ${use_yaml} == ".T." ) then
+  cp ${BUILD_AREA}/tables/data_table.yaml data_table.yaml
+  cp ${BUILD_AREA}/tables/field_table_6species_tke.yaml field_table.yaml
+else
+  cp ${BUILD_AREA}/tables/data_table data_table
+  cp ${BUILD_AREA}/tables/field_table_6species_tke field_table
+endif
+cp ${BUILD_AREA}/tables/diag_table_no3d diag_table
+cp $executable .
+
+# GFS standard input data
+tar xf ${GFS_STD_INPUT}
+
+# Grid and orography data
+ cp -rf ${GRIDDIR}/* INPUT/
+
+# build the date for curr_date from DATE
+set y = `echo ${DATE} | cut -c1-4`
+set m = `echo ${DATE} | cut -c5-6`
+set d = `echo ${DATE} | cut -c7-8`
+set h = `echo ${DATE} | cut -c10-11`
+set echo
+set curr_date = "${y},${m},${d},${h},0,0"
+
+# build the diag_table with the experiment name and date stamp
+cat >! diag_table << EOF
+${DATE}.${GRID}.${MODE}
+$y $m $d $h 0 0 
+EOF
+
+rm -f $WORKDIR/rundir/INPUT/gk03_CF0.nc
+cp $FIXDIR/global_sfc_emissivity_idx.txt INPUT/sfc_emissivity_idx.txt
+cp INPUT/aerosol.dat .
+cp INPUT/co2historicaldata_*.txt .
+cp INPUT/sfc_emissivity_idx.txt .
+cp INPUT/solarconstant_noaa_an.txt .
+
+cp $FIXDIR/global_glacier.2x2.grb INPUT/
+cp $FIXDIR/global_maxice.2x2.grb INPUT/
+cp $FIXDIR/RTGSST.1982.2012.monthly.clim.grb INPUT/
+cp $FIXDIR/global_snoclim.1.875.grb INPUT/
+cp $CLIMO_DATA/mld/mld_DR003_c1m_reg2.0.grb INPUT/
+cp $FIXDIR/global_snowfree_albedo.bosu.t1534.3072.1536.rg.grb INPUT/
+cp $FIXDIR/global_albedo4.1x1.grb INPUT/
+cp $FIXDIR/CFSR.SEAICE.1982.2012.monthly.clim.grb INPUT/
+cp $FIXDIR/global_tg3clim.2.6x1.5.grb INPUT/
+cp $FIXDIR/global_vegfrac.0.144.decpercent.grb INPUT/
+cp $FIXDIR/global_vegtype.igbp.t1534.3072.1536.rg.grb INPUT/
+cp $FIXDIR/global_soiltype.statsgo.t1534.3072.1536.rg.grb INPUT/
+cp $FIXDIR/global_soilmgldas.t1534.3072.1536.grb INPUT/
+cp $FIXDIR/seaice_newland.grb INPUT/
+cp $FIXDIR/global_shdmin.0.144x0.144.grb INPUT/
+cp $FIXDIR/global_shdmax.0.144x0.144.grb INPUT/
+cp $FIXDIR/global_slope.1x1.grb INPUT/
+cp $FIXDIR/global_mxsnoalb.uariz.t1534.3072.1536.rg.grb INPUT/
+
+
+unset echo
+cat >! input.nml <<EOF
+ &amip_interp_nml
+     interp_oi_sst = .true.
+     use_ncep_sst = .true.
+     use_ncep_ice = .false.
+     no_anom_sst = .false.
+     data_set = 'reynolds_oi',
+     date_out_of_range = 'climo',
+/
+
+ &external_ic_nml
+       filtered_terrain = .T.
+       levp = 64
+       gfs_dwinds = .T.
+       checker_tr = .F.
+       nt_checker = 0
+/
+
+ &atmos_model_nml
+     blocksize = $blocksize
+     chksum_debug = .F.
+     dycore_only = .F.
+     fdiag = $fdiag
+/
+
+ &fms_io_nml
+       checksum_required   = .false.
+       max_files_r = 100,
+       max_files_w = 100,
+/
+
+ &fms_nml
+       clock_grain = 'ROUTINE',
+       domains_stack_size = 3000000,
+       print_memory_usage = .false.
+/
+
+ &fms_affinity_nml
+      affinity=.false.
+/
+
+ &fv_grid_nml
+       grid_file = 'INPUT/grid_spec.nc'
+/
+
+ &fv_core_nml
+       layout   = $layout_x,$layout_y
+       io_layout = $io_layout
+       npx      = $npx
+       npy      = $npy
+       ntiles   = 6
+       npz    = $npz
+       grid_type = 0
+       make_nh = $make_nh
+       fv_debug = .F.
+       range_warn = .F.
+       reset_eta = .F.
+       n_sponge = 30
+       nudge_qv = .T.
+       rf_fast = .F.
+       tau = 5.
+       rf_cutoff = 7.5e2
+       d2_bg_k1 = 0.2
+       d2_bg_k2 = 0.1
+       kord_tm = -9
+       kord_mt =  9
+       kord_wz =  9
+       kord_tr =  9
+       hydrostatic = $hydrostatic
+       phys_hydrostatic = $phys_hydrostatic
+       use_hydro_pressure = $use_hydro_pressure
+       beta = 0.
+       a_imp = 1.
+       p_fac = 0.1
+       k_split  = $k_split
+       n_split  = $n_split
+       nwat = 6
+       na_init = $na_init
+       d_ext = 0.0
+       dnats = 2
+       fv_sg_adj = 600
+       d2_bg = 0.
+       nord =  3
+       dddmp = 0.2
+       d4_bg = 0.15
+       vtdm4 = 0.03
+       delt_max = 0.002
+       ke_bg = 0.
+       do_vort_damp = $do_vort_damp
+       external_ic = .F.
+       is_ideal_case = .T.
+       gfs_phil = $gfs_phil
+       !nggps_ic = $external_ic
+       nggps_ic = $nggps_ic
+       !ecmwf_ic = $ecmwf_ic
+       !res_latlon_dynamics = 'INPUT/gk03_CF0.nc'
+       mountain = $mountain
+       ncep_ic = .F.
+       d_con = $d_con
+       hord_mt = 6
+       hord_vt = 6
+       hord_tm = 6
+       hord_dp = 6
+       hord_tr = 8
+       adjust_dry_mass = .F.
+       consv_te = $consv_te
+       consv_am = .F.
+       fill = .T.
+       dwind_2d = .F.
+       print_freq = $print_freq
+       warm_start = .F.
+       no_dycore = $no_dycore
+       z_tracer = .T.
+/
+
+ &integ_phys_nml
+       do_inline_mp = .T.
+       do_sat_adj = .F.
+/
+
+!&fv_diag_column_nml
+!    do_diag_debug = .F.
+!    do_diag_sonde = .T.
+!    sound_freq = 1
+!    !diag_debug_names = 'ORD','Princeton'
+!    !diag_debug_lon_in = 272.,285.33
+!    !diag_debug_lat_in = 42.,  40.36
+!    diag_sonde_names =  'OUN',  'Amarillo', 'DelRio', 'Jackson', 'ILX',  'AtlanticCity', 'DodgeCity',
+!    diag_sonde_lon_in = -97.47,  -101.70,    -100.92,  -90.08,   -89.34,     -74.56,       -99.97,
+!    diag_sonde_lat_in =  35.22,    35.22,      29.37,   32.32,    40.15,      39.45,        37.77,    
+!    runname = ${GRID}.${MEMO}
+!/
+
+
+ &coupler_nml
+!       debug_affinity=.true.
+       months = $months
+       days  = $days
+       hours = $hours
+       seconds = $seconds
+       dt_atmos = $dt_atmos
+       !dt_ocean = $dt_atmos
+       current_date =  $curr_date
+       calendar = 'julian'
+       !memuse_verbose = .false.
+       atmos_nthreads = $nthreads
+       use_hyper_thread = $hyperthread
+!       ncores_per_node = $cores_per_node
+       ice_npes = -1
+       land_npes = -1
+       do_ocean=.False.
+       dt_cpld = $dt_atmos
+       do_flux=.False.
+       do_land=.False.
+       do_ice=.False.
+/
+
+&test_case_nml ! cold start
+    test_case = 14
+/
+
+ &gfs_physics_nml
+       fhzero         = $fhzer
+       ldiag3d        = .false.
+       fhcyc          = $fhcyc
+       nst_anl        = .true.
+       use_ufo        = .true.
+       pre_rad        = .false.
+       ncld           = 5
+       zhao_mic       = .false.
+       pdfcld         = .true.
+       fhswr          = 3600.
+       fhlwr          = 3600.
+       ialb           = 1
+       iems           = 1
+       IAER           = 111
+       ico2           = 2
+       isubc_sw       = 2
+       isubc_lw       = 2
+       isol           = 2
+       lwhtr          = .true.
+       swhtr          = .true.
+       cnvgwd         = .true.
+       do_deep        = .true.
+       shal_cnv       = .true.
+       cal_pre        = .false.
+       redrag         = .true.
+       dspheat        = .true.
+       hybedmf        = .false.
+       random_clds    = .false.
+       trans_trac     = .true.
+       cnvcld         = .false.
+       imfshalcnv     = 2
+       imfdeepcnv     = 2
+       cdmbgwd        = 3.5, 0.25
+       prslrd0        = 0.
+       ivegsrc        = 1
+       isot           = 1
+       ysupbl         = .false.
+       rlmx           = 500.0
+       do_dk_hb19     = .false.
+       xkzminv        = 0.0
+       xkzm_m         = 1.5
+       xkzm_h         = 1.5
+       xkzm_ml        = 1.0
+       xkzm_hl        = 1.0
+       xkzm_mi        = 1.5
+       xkzm_hi        = 1.5
+       cap_k0_land    = .false.
+       cloud_gfdl     = .true.
+       do_ocean       = .true.
+       satmedmf       = .true.
+       isatmedmf      = 0
+       do_sat_adj     = .false.
+       do_z0_hwrf17_hwonly = .true.
+/
+
+ &ocean_nml
+     mld_option       = "obs"
+     ocean_option     = "MLM"
+     restore_method   = 2
+     mld_obs_ratio    = 1.
+     use_rain_flux    = .true.
+     sst_restore_tscale = 2.
+     start_lat        = -30.
+     end_lat          = 30.
+     Gam              = 0.2
+     use_old_mlm      = .true.
+     do_mld_restore   = .true.
+     mld_restore_tscale = 2.
+     stress_ratio     = 1.
+     eps_day          = 10.
+/
+
+ &gfdl_mp_nml
+       do_sedi_heat = .false.
+       !rad_snow = .true.
+       !rad_graupel = .true.
+       !rad_rain = .true.
+       !const_vi = .false.
+       !const_vs = .false.
+       !const_vg = .false.
+       !const_vr = .false.
+       !vi_fac = 1.
+       !vs_fac = 1.
+       !vg_fac = 1.
+       !vr_fac = 1.
+       vi_max = 1.
+       vs_max = 2.
+       vg_max = 12.
+       vr_max = 12.
+       qi_lim = 1.
+       prog_ccn = .true.
+       do_qa = .true.
+       tau_l2v = 225.
+       tau_v2l = 150.
+       rthresh = 8.e-6  ! This is a key parameter for cloud water
+       dw_land  = 0.16
+       dw_ocean = 0.10
+       ql_mlt = 1.0e-3
+       qi0_crt = 8.0E-5
+       !qs0_crt = 1.0e-3
+       !tau_i2s = 1000.
+       c_psaci = 0.35
+       !c_pgacs = 0.01
+       rh_inc = 0.30
+       rh_inr = 0.30
+       !ccn_l = 300.
+       !ccn_o = 100.
+       c_paut = 0.5
+/
+
+ &diag_manager_nml
+       prepend_date = .F.
+/
+
+  &interpolator_nml
+       interp_method = 'conserve_great_circle'
+/
+
+&namsfc
+       FNGLAC   = "INPUT/global_glacier.2x2.grb",
+       FNMXIC   = "INPUT/global_maxice.2x2.grb",
+       FNTSFC   = "INPUT/RTGSST.1982.2012.monthly.clim.grb",
+       FNSNOC   = "INPUT/global_snoclim.1.875.grb",
+       FNMLDC   = "INPUT/mld_DR003_c1m_reg2.0.grb",
+       FNZORC   = "igbp",
+       FNALBC   = "INPUT/global_snowfree_albedo.bosu.t1534.3072.1536.rg.grb",
+       FNALBC2  = "INPUT/global_albedo4.1x1.grb",
+       FNAISC   = "INPUT/CFSR.SEAICE.1982.2012.monthly.clim.grb",
+       FNTG3C   = "INPUT/global_tg3clim.2.6x1.5.grb",
+       FNVEGC   = "INPUT/global_vegfrac.0.144.decpercent.grb",
+       FNVETC   = "INPUT/global_vegtype.igbp.t1534.3072.1536.rg.grb",
+       FNSOTC   = "INPUT/global_soiltype.statsgo.t1534.3072.1536.rg.grb",
+       FNSMCC   = "INPUT/global_soilmgldas.t1534.3072.1536.grb",
+       FNMSKH   = "INPUT/seaice_newland.grb",
+       FNTSFA   = "",
+       FNACNA   = "",
+       FNSNOA   = "",
+       FNVMNC   = "INPUT/global_shdmin.0.144x0.144.grb",
+       FNVMXC   = "INPUT/global_shdmax.0.144x0.144.grb",
+       FNSLPC   = "INPUT/global_slope.1x1.grb",
+       FNABSC   = "INPUT/global_mxsnoalb.uariz.t1534.3072.1536.rg.grb",
+       LDEBUG   =.false.,
+       FSMCL(2) = 99999
+       FSMCL(3) = 99999
+       FSMCL(4) = 99999
+       FTSFS    = 90
+       FAISS    = 99999
+       FSNOL    = 99999
+       FSICL    = 99999
+       FTSFL    = 99999,
+       FAISL    = 99999,
+       FVETL    = 99999,
+       FSOTL    = 99999,
+       FvmnL    = 99999,
+       FvmxL    = 99999,
+       FSLPL    = 99999,
+       FABSL    = 99999,
+       FSNOS    = 99999,
+       FSICS    = 99999,
+/
+
+  &cld_eff_rad_nml
+/
+
+EOF
+
+if ( ${use_yaml} == ".T." ) then
+  cat >> input.nml << EOF
+
+ &field_manager_nml
+       use_field_table_yaml = $use_yaml
+/
+
+ &data_override_nml
+       use_data_table_yaml = $use_yaml
+/
+EOF
+endif
+
+# run the executable
+${run_cmd} | tee fms.out || exit
+@ num ++
+echo "set num = ${num}" >! ${RST_COUNT}
+
+#########################################################################
+# generate date for file names
+########################################################################
+
+set begindate = `$TIME_STAMP -bhf digital`
+if ( $begindate == "" ) set begindate = tmp`date '+%j%H%M%S'`
+
+set enddate = `$TIME_STAMP -ehf digital`
+if ( $enddate == "" ) set enddate = tmp`date '+%j%H%M%S'`
+set fyear = `echo $enddate | cut -c -4`
+
+cd $WORKDIR/rundir
+cat time_stamp.out
+
+########################################################################
+# save ascii output files
+########################################################################
+
+if ( ! -d $WORKDIR/ascii ) mkdir $WORKDIR/ascii
+if ( ! -d $WORKDIR/ascii ) then
+ echo "ERROR: $WORKDIR/ascii is not a directory."
+ exit 1
+endif
+
+mkdir -p $WORKDIR/ascii/$begindate
+foreach out (`ls *.out *.results input*.nml *_table`)
+  mv $out $WORKDIR/ascii/$begindate/
+end
+
+cd $WORKDIR/ascii/$begindate
+tar cvf - *\.out *\.results | gzip -c > $WORKDIR/ascii/$begindate.ascii_out.tgz
+
+#if ($NO_SEND == "send") sbatch --export=source=$WORKDIR/ascii/$begindate.ascii_out.tgz,destination=gfdl:$gfdl_archive/ascii/$begindate.ascii_out.tgz,extension=null,type=ascii $SEND_FILE
+
+########################################################################
+# move restart files
+########################################################################
+
+cd $WORKDIR
+
+#if ( ! -d $WORKDIR/restart ) mkdir -p $WORKDIR/restart
+
+if ( ! -d $WORKDIR/restart ) then
+  echo "ERROR: $WORKDIR/restart is not a directory."
+  exit
+endif
+
+set resfile_list = $WORKDIR/rundir/file.restart.list.txt
+find $WORKDIR/rundir/RESTART -iname '*.res*' >! $resfile_list
+find $WORKDIR/rundir/RESTART -iname '*_data*' >> $resfile_list
+set resfiles     = `wc -l $resfile_list | awk '{print $1}'`
+
+if ( $resfiles > 0 ) then
+
+  set dateDir = $WORKDIR/restart/$enddate
+  set restart_dir = $dateDir
+
+  if ( ! -d $dateDir ) mkdir -p $dateDir
+
+  if ( ! -d $dateDir ) then
+    echo "ERROR: $dateDir is not a directory."
+    exit
+  endif
+
+  xargs mv -t $restart_dir < $resfile_list
+  echo "set restart_dir = $restart_dir" >> $RST_COUNT
+
+#  if ($NO_SEND == "send") sbatch --export=source=$WORKDIR/restart/$enddate,destination=gfdl:$gfdl_archive/restart/$enddate,extension=tar,type=restart $SEND_FILE
+
+endif
+
+
+########################################################################
+# move history files
+########################################################################
+
+cd $WORKDIR
+
+if ( ! -d $WORKDIR/history ) mkdir -p $WORKDIR/history
+if ( ! -d $WORKDIR/history ) then
+  echo "ERROR: $WORKDIR/history is not a directory."
+  exit 1
+endif
+
+set dateDir = $WORKDIR/history/$begindate
+if ( ! -d  $dateDir ) mkdir $dateDir
+if ( ! -d  $dateDir ) then
+  echo "ERROR: $dateDir is not a directory."
+  exit 1
+endif
+
+find $WORKDIR/rundir -maxdepth 1 -type f -regex '.*.nc'      -exec mv {} $dateDir \;
+find $WORKDIR/rundir -maxdepth 1 -type f -regex '.*.nc.....' -exec mv {} $dateDir \;
+
+cd $dateDir
+
+#sbatch --export=source=$WORKDIR/history/${begindate},destination=gfdl:$gfdl_archive/history/${begindate},extension=untar,type=history $SEND_FILE
+
+
+cd $WORKDIR/rundir
+
+
+if ($num < $NUM_TOT) then
+  echo "resubmitting... "
+  if ( "$SLURM_JOB_NAME" == "sh" ) then
+   cd $SCRIPT_AREA
+    ./$SCRIPT:t
+  else
+    cd $SCRIPT_AREA
+    #sbatch --export=ALL,DATE=${DATE} $SCRIPT:t
+    #sbatch -J ${DATE}.`basename $SLURM_JOB_NAME` --export=ALL,DATE=${DATE} $SCRIPT:t
+  echo "sleeping ... "
+    sleep 20
+  endif
+endif

--- a/RTS/GAEA_RTS/serialbox/C48_res.aquaplanet.csh
+++ b/RTS/GAEA_RTS/serialbox/C48_res.aquaplanet.csh
@@ -12,8 +12,8 @@ set echo
 set YourGroup  = "gfdl_f" #modify this to be your own group on f5
 set BASEDIR    = "/gpfs/f5/${YourGroup}/scratch/${USER}/"
 set INPUT_DATA = "/gpfs/f5/gfdl_w/proj-shared/fvGFS_INPUT_DATA"
-#set BUILD_AREA = "/ncrc/home1/${USER}/SHiELD_dev/SHiELD_build/"
-set BUILD_AREA = "/ncrc/home1/${USER}/work/20260129_translate_tests/PRs/SHiELD_build"
+set BUILD_AREA = "/ncrc/home1/${USER}/SHiELD_dev/SHiELD_build/"
+
 
 if ( ! $?COMPILER ) then
   set COMPILER = "intel"

--- a/RTS/GAEA_RTS/serialbox/C48_res.baroclinic.csh
+++ b/RTS/GAEA_RTS/serialbox/C48_res.baroclinic.csh
@@ -1,0 +1,767 @@
+#!/bin/tcsh
+#SBATCH --output=./stdout/%x.%j
+#SBATCH --job-name=C48_res_baroclinic
+#SBATCH --clusters=c5
+#SBATCH --time=00:60:00
+#SBATCH --nodes=3
+
+# see run_tests.sh for an example of how to run these tests
+
+set echo
+
+set YourGroup  = "gfdl_f" #modify this to be your own group on f5
+set BASEDIR    = "/gpfs/f5/${YourGroup}/scratch/${USER}/"
+set INPUT_DATA = "/gpfs/f5/gfdl_w/proj-shared/fvGFS_INPUT_DATA"
+#set BUILD_AREA = "/ncrc/home1/${USER}/SHiELD_dev/SHiELD_build/"
+set BUILD_AREA = "/ncrc/home1/${USER}/work/20260129_translate_tests/PRs/SHiELD_build"
+
+if ( ! $?COMPILER ) then
+  set COMPILER = "intel"
+endif
+
+set RELEASE = "`cat ${BUILD_AREA}/../SHiELD_SRC/release`"
+
+set SERIALBOX_ROOT=${BUILD_AREA}/Build/serialbox/${COMPILER}/serialbox2/build/install
+set LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${SERIALBOX_ROOT}/lib
+echo $LD_LIBRARY_PATH
+
+source ${BUILD_AREA}/site/environment.${COMPILER}.csh
+
+#set hires_oro_factor = 3
+set res = 48
+
+set CPN = 40
+# case specific details
+set TYPE = "nh"         # choices:  nh, hydro
+if ( ! $?MODE ) then
+  set MODE = "32bit"      # choices:  32bit, 64bit
+endif
+set MONO = "non-mono"   # choices:  mono, non-mono
+set GRID = "C$res"
+set MEMO = "$SLURM_JOB_NAME" # trying prod executable
+set HYPT = "off"         # choices:  on, off  (controls hyperthreading)
+if ( ! $?COMP ) then
+  set COMP = "repro"       # choices:  debug, repro, prod
+endif
+set NO_SEND = "no_send"    # choices:  send, no_send  # send option not available yet
+set NUM_TOT = 4         # run cycle, 1: no restart 
+if (! $?DATE) then
+    set DATE=20160801.00Z
+else
+    echo $DATE
+endif
+set NAME = $DATE
+set CASE = "C$res"
+set EXE = "x"
+
+# directory structure
+set WORKDIR    = ${BASEDIR}/SHiELD_${RELEASE}/${NAME}.${CASE}.${TYPE}.${COMP}.${MODE}.${COMPILER}.${MONO}.${MEMO}/
+set executable = ${BUILD_AREA}/Build/bin/SHiELD_${TYPE}.${COMP}.${MODE}.${COMPILER}.${EXE}
+
+# sending file to gfdl
+#set gfdl_archive = /archive/${USER}/SHiELD_S2S/${NAME}.${CASE}.${TYPE}.${MODE}.${MEMO}/
+#set SEND_FILE = ~${USER}/Util/send_file_slurm.csh
+set TIME_STAMP = ${BUILD_AREA}/site/time_stamp.csh
+
+# input filesets
+set ICDIR   = ${INPUT_DATA}/global.v201810/${CASE}/${NAME}_IC/  #CHECK
+set ICS     = ${ICDIR}/GFS_INPUT.tar
+set FIXDIR  = ${INPUT_DATA}/fix.v201810/
+set CLIMO_DATA = ${INPUT_DATA}/climo_data.v201807/
+set GFS_STD_INPUT  = ${INPUT_DATA}/GFS_STD_INPUT.20160311.tar #This should remain a tarball
+set GRIDDIR = ${INPUT_DATA}/global.v201810/${CASE}/GRID/ #CHECK
+
+
+# changeable parameters
+    # dycore definitions
+    set npx = "49"
+    set npy = "49"
+    set npz = "79"
+    set layout_x = "1"
+    set layout_y = "1"
+    set io_layout = "1,1"
+    set nthreads = "4"
+
+    # blocking factor used for threading and general physics performance
+    set blocksize = "32"
+
+    # run length
+    set months = "0"
+    set days = "0"
+    set hours = "1"
+    set seconds = "0"
+    set dt_atmos = "450"
+
+    #fms yaml
+    set use_yaml=".F." #if True, requires data_table.yaml and field_table.yaml
+
+# variables for gfs diagnostic output intervals and time to zero out time-accumulated data
+#set fdiag = "6.,12.,18.,24.,30.,36.,42.,48.,54.,60.,66.,72.,78.,84.,90.,96.,102.,108.,114.,120.,126.,132.,138.,144.,150.,156.,162.,168.,174.,180.,186.,192.,198.,204.,210.,216.,222.,228.,234.,240."
+set fdiag = "3.0"
+set fhzer = "3.0"
+set fhcyc = "24."
+
+# determines whether FV3 or GFS physics calculate geopotential
+set gfs_phil = ".false." 
+
+# determine whether ozone production occurs in GFS physics                                         
+set ozcalc = ".true."                                                                              
+                                                                                                           
+# set various debug options                                                                        
+set no_dycore = ".false."                                                                          
+set dycore_only = ".false."                                                                        
+set chksum_debug = ".false."                                                                       
+set print_freq = "6"         
+
+if (${TYPE} == "nh") then
+  # non-hydrostatic options
+  set make_nh = ".T."
+  set hydrostatic = ".F."
+  set phys_hydrostatic = ".F."     # can be tested
+  set use_hydro_pressure = ".F."   # can be tested
+  set consv_te = "1."
+  set k_split = "1"
+  set n_split = "2"
+else
+  # hydrostatic options
+  set make_nh = ".F."
+  set hydrostatic = ".T."
+  set phys_hydrostatic = ".F."     # will be ignored in hydro mode
+  set use_hydro_pressure = ".T."   # have to be .T. in hydro mode
+  set consv_te = "0."
+  set k_split = "1"
+  set n_split = "2"
+endif
+
+if (${MONO} == "mono" || ${MONO} == "monotonic") then                                              
+  # monotonic options                                                                              
+  set d_con = "1."                                                                                 
+  set do_vort_damp = ".false."                                                                     
+else                                                                                               
+  # non-monotonic options                                                                          
+  set d_con = "1."                                                                                 
+  set do_vort_damp = ".true."                                                                      
+endif                                                                                              
+
+
+# variables for hyperthreading
+set cores_per_node = $CPN
+if (${HYPT} == "on") then
+  set hyperthread = ".true."
+  set j_opt = "-j2"
+  set div = 2
+else
+  set hyperthread = ".false."
+  set j_opt = "-j1"
+  set div = 1
+endif
+
+# when running with threads, need to use the following command
+    @ npes = ${layout_x} * ${layout_y} * 6
+    @ skip = ${nthreads} / ${div}
+    set run_cmd = "srun --ntasks=$npes --cpus-per-task=$skip ./$executable:t"
+
+    setenv MPICH_ENV_DISPLAY
+    setenv MPICH_MPIIO_CB_ALIGN 2
+    setenv MALLOC_TRIM_THRESHOLD_ 536870912
+    setenv NC_BLKSZ 1M
+# necessary for OpenMP when using Intel
+    setenv KMP_STACKSIZE 256m
+    setenv SLURM_CPU_BIND verbose
+
+
+set SCRIPT_AREA = $PWD
+#if ( "$PBS_JOBDATE" == "BATCH" | "$PBS_JOBNAME" == "STDIN" ) then
+if ( "$SLURM_JOB_NAME" == "sh" ) then
+  set SCRIPT = "${SCRIPT_AREA}/$0"
+else
+  set SCRIPT = "${SCRIPT_AREA}/$SLURM_JOB_NAME"
+endif
+#set RST_COUNT = ${SCRIPT}.rst.count
+mkdir -p $WORKDIR/restart
+set RST_COUNT = $WORKDIR/restart/rst.count
+#######DEBUG
+#\rm -f $RST_COUNT
+#######END DEBUG
+if ( -f ${RST_COUNT} ) then
+  source ${RST_COUNT}
+  #set num = `cat ${RST_COUNT} | tr -d -c '[0-9]'`
+  if ( x"$num" == "x" || ${num} < 1 ) then
+    set RESTART_RUN = "F"
+    echo " Restart = F"
+  else
+    set RESTART_RUN = "T"
+    echo " Restart = T"
+  endif
+else
+  set num = 0
+  set RESTART_RUN = "F"
+    echo " Restart = FF"
+endif
+
+#set RESTART_RUN = "F"
+
+#NEED TO BE CAREFUL OF SETUP CODE WRT RESTARTS!!
+if (${RESTART_RUN} == "F") then
+
+  \rm -rf $WORKDIR/rundir
+
+  mkdir -p $WORKDIR/rundir
+  cd $WORKDIR/rundir
+
+  mkdir -p RESTART
+  mkdir -p INPUT
+
+  # Date specific ICs
+  cp -rf ${ICDIR}/* INPUT/
+
+  # set variables in input.nml for initial run
+  set ecmwf_ic = ".F." 
+  set nggps_ic = ".T."
+  set mountain = ".F."
+  set external_ic = ".T."
+  set warm_start = ".F."
+  set na_init = 0
+
+else
+
+  cd $WORKDIR/rundir
+  \rm -rf INPUT/*
+
+  # move the restart data into INPUT/
+  #mv RESTART/* INPUT/.
+  cp -rf ${restart_dir}/coupler.res ${restart_dir}/[^0-9]*.nc ${restart_dir}/[^0-9]*.nc.???? INPUT/.
+
+  # reset values in input.nml for restart run
+  set make_nh = ".F."
+  set nggps_ic = ".F."
+  set ecmwf_ic = ".F."
+  set mountain = ".T."
+  set external_ic = ".F."
+  set warm_start = ".T."
+  set na_init = 0
+
+endif
+ls INPUT/
+ls RESTART/
+
+# copy over the other tables and executable
+if ( ${use_yaml} == ".T." ) then
+  cp ${BUILD_AREA}/tables/data_table.yaml data_table.yaml
+  cp ${BUILD_AREA}/tables/field_table_6species_tke.yaml field_table.yaml
+else
+  cp ${BUILD_AREA}/tables/data_table data_table
+  cp ${BUILD_AREA}/tables/field_table_6species_tke field_table
+endif
+cp ${BUILD_AREA}/tables/diag_table_no3d diag_table
+cp $executable .
+
+# GFS standard input data
+tar xf ${GFS_STD_INPUT}
+
+# Grid and orography data
+ cp -rf ${GRIDDIR}/* INPUT/
+
+# build the date for curr_date from DATE
+set y = `echo ${DATE} | cut -c1-4`
+set m = `echo ${DATE} | cut -c5-6`
+set d = `echo ${DATE} | cut -c7-8`
+set h = `echo ${DATE} | cut -c10-11`
+set echo
+set curr_date = "${y},${m},${d},${h},0,0"
+
+# build the diag_table with the experiment name and date stamp
+cat >! diag_table << EOF
+${DATE}.${GRID}.${MODE}
+$y $m $d $h 0 0 
+EOF
+
+rm -f $WORKDIR/rundir/INPUT/gk03_CF0.nc
+cp $FIXDIR/global_sfc_emissivity_idx.txt INPUT/sfc_emissivity_idx.txt
+cp INPUT/aerosol.dat .
+cp INPUT/co2historicaldata_*.txt .
+cp INPUT/sfc_emissivity_idx.txt .
+cp INPUT/solarconstant_noaa_an.txt .
+
+cp $FIXDIR/global_glacier.2x2.grb INPUT/
+cp $FIXDIR/global_maxice.2x2.grb INPUT/
+cp $FIXDIR/RTGSST.1982.2012.monthly.clim.grb INPUT/
+cp $FIXDIR/global_snoclim.1.875.grb INPUT/
+cp $CLIMO_DATA/mld/mld_DR003_c1m_reg2.0.grb INPUT/
+cp $FIXDIR/global_snowfree_albedo.bosu.t1534.3072.1536.rg.grb INPUT/
+cp $FIXDIR/global_albedo4.1x1.grb INPUT/
+cp $FIXDIR/CFSR.SEAICE.1982.2012.monthly.clim.grb INPUT/
+cp $FIXDIR/global_tg3clim.2.6x1.5.grb INPUT/
+cp $FIXDIR/global_vegfrac.0.144.decpercent.grb INPUT/
+cp $FIXDIR/global_vegtype.igbp.t1534.3072.1536.rg.grb INPUT/
+cp $FIXDIR/global_soiltype.statsgo.t1534.3072.1536.rg.grb INPUT/
+cp $FIXDIR/global_soilmgldas.t1534.3072.1536.grb INPUT/
+cp $FIXDIR/seaice_newland.grb INPUT/
+cp $FIXDIR/global_shdmin.0.144x0.144.grb INPUT/
+cp $FIXDIR/global_shdmax.0.144x0.144.grb INPUT/
+cp $FIXDIR/global_slope.1x1.grb INPUT/
+cp $FIXDIR/global_mxsnoalb.uariz.t1534.3072.1536.rg.grb INPUT/
+
+
+unset echo
+cat >! input.nml <<EOF
+ &amip_interp_nml
+     interp_oi_sst = .true.
+     use_ncep_sst = .true.
+     use_ncep_ice = .false.
+     no_anom_sst = .false.
+     data_set = 'reynolds_oi',
+     date_out_of_range = 'climo',
+/
+
+ &external_ic_nml
+       filtered_terrain = .T.
+       levp = 64
+       gfs_dwinds = .T.
+       checker_tr = .F.
+       nt_checker = 0
+/
+
+ &atmos_model_nml
+     blocksize = $blocksize
+     chksum_debug = .F.
+     dycore_only = .F.
+     fdiag = $fdiag
+/
+
+ &fms_io_nml
+       checksum_required   = .false.
+       max_files_r = 100,
+       max_files_w = 100,
+/
+
+ &fms_nml
+       clock_grain = 'ROUTINE',
+       domains_stack_size = 3000000,
+       print_memory_usage = .false.
+/
+
+ &fms_affinity_nml
+      affinity=.false.
+/
+
+ &fv_grid_nml
+       grid_file = 'INPUT/grid_spec.nc'
+/
+
+ &fv_core_nml
+       layout   = $layout_x,$layout_y
+       io_layout = $io_layout
+       npx      = $npx
+       npy      = $npy
+       ntiles   = 6
+       npz    = $npz
+       grid_type = 0
+       make_nh = $make_nh
+       fv_debug = .F.
+       range_warn = .F.
+       reset_eta = .F.
+       n_sponge = 30
+       nudge_qv = .T.
+       rf_fast = .F.
+       tau = 5.
+       rf_cutoff = 7.5e2
+       d2_bg_k1 = 0.2
+       d2_bg_k2 = 0.1
+       kord_tm = -9
+       kord_mt =  9
+       kord_wz =  9
+       kord_tr =  9
+       hydrostatic = $hydrostatic
+       phys_hydrostatic = $phys_hydrostatic
+       use_hydro_pressure = $use_hydro_pressure
+       beta = 0.
+       a_imp = 1.
+       p_fac = 0.1
+       k_split  = $k_split
+       n_split  = $n_split
+       nwat = 6
+       na_init = $na_init
+       d_ext = 0.0
+       dnats = 2
+       fv_sg_adj = 600
+       d2_bg = 0.
+       nord =  3
+       dddmp = 0.2
+       d4_bg = 0.15
+       vtdm4 = 0.03
+       delt_max = 0.002
+       ke_bg = 0.
+       do_vort_damp = $do_vort_damp
+       external_ic = .F.
+       is_ideal_case = .T.
+       gfs_phil = $gfs_phil
+       !nggps_ic = $external_ic
+       nggps_ic = $nggps_ic
+       !ecmwf_ic = $ecmwf_ic
+       !res_latlon_dynamics = 'INPUT/gk03_CF0.nc'
+       mountain = $mountain
+       ncep_ic = .F.
+       d_con = $d_con
+       hord_mt = 6
+       hord_vt = 6
+       hord_tm = 6
+       hord_dp = 6
+       hord_tr = 8
+       adjust_dry_mass = .F.
+       consv_te = $consv_te
+       consv_am = .F.
+       fill = .T.
+       dwind_2d = .F.
+       print_freq = $print_freq
+       warm_start = .F.
+       no_dycore = $no_dycore
+       z_tracer = .T.
+/
+
+ &integ_phys_nml
+       do_inline_mp = .T.
+       do_sat_adj = .F.
+/
+
+!&fv_diag_column_nml
+!    do_diag_debug = .F.
+!    do_diag_sonde = .T.
+!    sound_freq = 1
+!    !diag_debug_names = 'ORD','Princeton'
+!    !diag_debug_lon_in = 272.,285.33
+!    !diag_debug_lat_in = 42.,  40.36
+!    diag_sonde_names =  'OUN',  'Amarillo', 'DelRio', 'Jackson', 'ILX',  'AtlanticCity', 'DodgeCity',
+!    diag_sonde_lon_in = -97.47,  -101.70,    -100.92,  -90.08,   -89.34,     -74.56,       -99.97,
+!    diag_sonde_lat_in =  35.22,    35.22,      29.37,   32.32,    40.15,      39.45,        37.77,    
+!    runname = ${GRID}.${MEMO}
+!/
+
+
+ &coupler_nml
+!       debug_affinity=.true.
+       months = $months
+       days  = $days
+       hours = $hours
+       seconds = $seconds
+       dt_atmos = $dt_atmos
+       !dt_ocean = $dt_atmos
+       current_date =  $curr_date
+       calendar = 'julian'
+       !memuse_verbose = .false.
+       atmos_nthreads = $nthreads
+       use_hyper_thread = $hyperthread
+!       ncores_per_node = $cores_per_node
+       ice_npes = -1
+       land_npes = -1
+       do_ocean=.False.
+       dt_cpld = $dt_atmos
+       do_flux=.False.
+       do_land=.False.
+       do_ice=.False.
+/
+
+&test_case_nml ! cold start
+    test_case = 13
+/
+
+ &gfs_physics_nml
+       fhzero         = $fhzer
+       ldiag3d        = .false.
+       fhcyc          = $fhcyc
+       nst_anl        = .true.
+       use_ufo        = .true.
+       pre_rad        = .false.
+       ncld           = 5
+       zhao_mic       = .false.
+       pdfcld         = .true.
+       fhswr          = 3600.
+       fhlwr          = 3600.
+       ialb           = 1
+       iems           = 1
+       IAER           = 111
+       ico2           = 2
+       isubc_sw       = 2
+       isubc_lw       = 2
+       isol           = 2
+       lwhtr          = .true.
+       swhtr          = .true.
+       cnvgwd         = .true.
+       do_deep        = .true.
+       shal_cnv       = .true.
+       cal_pre        = .false.
+       redrag         = .true.
+       dspheat        = .true.
+       hybedmf        = .false.
+       random_clds    = .false.
+       trans_trac     = .true.
+       cnvcld         = .false.
+       imfshalcnv     = 2
+       imfdeepcnv     = 2
+       cdmbgwd        = 3.5, 0.25
+       prslrd0        = 0.
+       ivegsrc        = 1
+       isot           = 1
+       ysupbl         = .false.
+       rlmx           = 500.0
+       do_dk_hb19     = .false.
+       xkzminv        = 0.0
+       xkzm_m         = 1.5
+       xkzm_h         = 1.5
+       xkzm_ml        = 1.0
+       xkzm_hl        = 1.0
+       xkzm_mi        = 1.5
+       xkzm_hi        = 1.5
+       cap_k0_land    = .false.
+       cloud_gfdl     = .true.
+       do_ocean       = .true.
+       satmedmf       = .true.
+       isatmedmf      = 0
+       do_sat_adj     = .false.
+       do_z0_hwrf17_hwonly = .true.
+/
+
+ &ocean_nml
+     mld_option       = "obs"
+     ocean_option     = "MLM"
+     restore_method   = 2
+     mld_obs_ratio    = 1.
+     use_rain_flux    = .true.
+     sst_restore_tscale = 2.
+     start_lat        = -30.
+     end_lat          = 30.
+     Gam              = 0.2
+     use_old_mlm      = .true.
+     do_mld_restore   = .true.
+     mld_restore_tscale = 2.
+     stress_ratio     = 1.
+     eps_day          = 10.
+/
+
+ &gfdl_mp_nml
+       do_sedi_heat = .false.
+       !rad_snow = .true.
+       !rad_graupel = .true.
+       !rad_rain = .true.
+       !const_vi = .false.
+       !const_vs = .false.
+       !const_vg = .false.
+       !const_vr = .false.
+       !vi_fac = 1.
+       !vs_fac = 1.
+       !vg_fac = 1.
+       !vr_fac = 1.
+       vi_max = 1.
+       vs_max = 2.
+       vg_max = 12.
+       vr_max = 12.
+       qi_lim = 1.
+       prog_ccn = .true.
+       do_qa = .true.
+       tau_l2v = 225.
+       tau_v2l = 150.
+       rthresh = 8.e-6  ! This is a key parameter for cloud water
+       dw_land  = 0.16
+       dw_ocean = 0.10
+       ql_mlt = 1.0e-3
+       qi0_crt = 8.0E-5
+       !qs0_crt = 1.0e-3
+       !tau_i2s = 1000.
+       c_psaci = 0.35
+       !c_pgacs = 0.01
+       rh_inc = 0.30
+       rh_inr = 0.30
+       !ccn_l = 300.
+       !ccn_o = 100.
+       c_paut = 0.5
+/
+
+ &diag_manager_nml
+       prepend_date = .F.
+/
+
+  &interpolator_nml
+       interp_method = 'conserve_great_circle'
+/
+
+&namsfc
+       FNGLAC   = "INPUT/global_glacier.2x2.grb",
+       FNMXIC   = "INPUT/global_maxice.2x2.grb",
+       FNTSFC   = "INPUT/RTGSST.1982.2012.monthly.clim.grb",
+       FNSNOC   = "INPUT/global_snoclim.1.875.grb",
+       FNMLDC   = "INPUT/mld_DR003_c1m_reg2.0.grb",
+       FNZORC   = "igbp",
+       FNALBC   = "INPUT/global_snowfree_albedo.bosu.t1534.3072.1536.rg.grb",
+       FNALBC2  = "INPUT/global_albedo4.1x1.grb",
+       FNAISC   = "INPUT/CFSR.SEAICE.1982.2012.monthly.clim.grb",
+       FNTG3C   = "INPUT/global_tg3clim.2.6x1.5.grb",
+       FNVEGC   = "INPUT/global_vegfrac.0.144.decpercent.grb",
+       FNVETC   = "INPUT/global_vegtype.igbp.t1534.3072.1536.rg.grb",
+       FNSOTC   = "INPUT/global_soiltype.statsgo.t1534.3072.1536.rg.grb",
+       FNSMCC   = "INPUT/global_soilmgldas.t1534.3072.1536.grb",
+       FNMSKH   = "INPUT/seaice_newland.grb",
+       FNTSFA   = "",
+       FNACNA   = "",
+       FNSNOA   = "",
+       FNVMNC   = "INPUT/global_shdmin.0.144x0.144.grb",
+       FNVMXC   = "INPUT/global_shdmax.0.144x0.144.grb",
+       FNSLPC   = "INPUT/global_slope.1x1.grb",
+       FNABSC   = "INPUT/global_mxsnoalb.uariz.t1534.3072.1536.rg.grb",
+       LDEBUG   =.false.,
+       FSMCL(2) = 99999
+       FSMCL(3) = 99999
+       FSMCL(4) = 99999
+       FTSFS    = 90
+       FAISS    = 99999
+       FSNOL    = 99999
+       FSICL    = 99999
+       FTSFL    = 99999,
+       FAISL    = 99999,
+       FVETL    = 99999,
+       FSOTL    = 99999,
+       FvmnL    = 99999,
+       FvmxL    = 99999,
+       FSLPL    = 99999,
+       FABSL    = 99999,
+       FSNOS    = 99999,
+       FSICS    = 99999,
+/
+
+  &cld_eff_rad_nml
+/
+
+EOF
+
+if ( ${use_yaml} == ".T." ) then
+  cat >> input.nml << EOF
+
+ &field_manager_nml
+       use_field_table_yaml = $use_yaml
+/
+
+ &data_override_nml
+       use_data_table_yaml = $use_yaml
+/
+EOF
+endif
+
+# run the executable
+${run_cmd} | tee fms.out || exit
+@ num ++
+echo "set num = ${num}" >! ${RST_COUNT}
+
+#########################################################################
+# generate date for file names
+########################################################################
+
+set begindate = `$TIME_STAMP -bhf digital`
+if ( $begindate == "" ) set begindate = tmp`date '+%j%H%M%S'`
+
+set enddate = `$TIME_STAMP -ehf digital`
+if ( $enddate == "" ) set enddate = tmp`date '+%j%H%M%S'`
+set fyear = `echo $enddate | cut -c -4`
+
+cd $WORKDIR/rundir
+cat time_stamp.out
+
+########################################################################
+# save ascii output files
+########################################################################
+
+if ( ! -d $WORKDIR/ascii ) mkdir $WORKDIR/ascii
+if ( ! -d $WORKDIR/ascii ) then
+ echo "ERROR: $WORKDIR/ascii is not a directory."
+ exit 1
+endif
+
+mkdir -p $WORKDIR/ascii/$begindate
+foreach out (`ls *.out *.results input*.nml *_table`)
+  mv $out $WORKDIR/ascii/$begindate/
+end
+
+cd $WORKDIR/ascii/$begindate
+tar cvf - *\.out *\.results | gzip -c > $WORKDIR/ascii/$begindate.ascii_out.tgz
+
+#if ($NO_SEND == "send") sbatch --export=source=$WORKDIR/ascii/$begindate.ascii_out.tgz,destination=gfdl:$gfdl_archive/ascii/$begindate.ascii_out.tgz,extension=null,type=ascii $SEND_FILE
+
+########################################################################
+# move restart files
+########################################################################
+
+cd $WORKDIR
+
+#if ( ! -d $WORKDIR/restart ) mkdir -p $WORKDIR/restart
+
+if ( ! -d $WORKDIR/restart ) then
+  echo "ERROR: $WORKDIR/restart is not a directory."
+  exit
+endif
+
+set resfile_list = $WORKDIR/rundir/file.restart.list.txt
+find $WORKDIR/rundir/RESTART -iname '*.res*' >! $resfile_list
+find $WORKDIR/rundir/RESTART -iname '*_data*' >> $resfile_list
+set resfiles     = `wc -l $resfile_list | awk '{print $1}'`
+
+if ( $resfiles > 0 ) then
+
+  set dateDir = $WORKDIR/restart/$enddate
+  set restart_dir = $dateDir
+
+  if ( ! -d $dateDir ) mkdir -p $dateDir
+
+  if ( ! -d $dateDir ) then
+    echo "ERROR: $dateDir is not a directory."
+    exit
+  endif
+
+  xargs mv -t $restart_dir < $resfile_list
+  echo "set restart_dir = $restart_dir" >> $RST_COUNT
+
+#  if ($NO_SEND == "send") sbatch --export=source=$WORKDIR/restart/$enddate,destination=gfdl:$gfdl_archive/restart/$enddate,extension=tar,type=restart $SEND_FILE
+
+endif
+
+
+########################################################################
+# move history files
+########################################################################
+
+cd $WORKDIR
+
+if ( ! -d $WORKDIR/history ) mkdir -p $WORKDIR/history
+if ( ! -d $WORKDIR/history ) then
+  echo "ERROR: $WORKDIR/history is not a directory."
+  exit 1
+endif
+
+set dateDir = $WORKDIR/history/$begindate
+if ( ! -d  $dateDir ) mkdir $dateDir
+if ( ! -d  $dateDir ) then
+  echo "ERROR: $dateDir is not a directory."
+  exit 1
+endif
+
+find $WORKDIR/rundir -maxdepth 1 -type f -regex '.*.nc'      -exec mv {} $dateDir \;
+find $WORKDIR/rundir -maxdepth 1 -type f -regex '.*.nc.....' -exec mv {} $dateDir \;
+
+cd $dateDir
+
+#sbatch --export=source=$WORKDIR/history/${begindate},destination=gfdl:$gfdl_archive/history/${begindate},extension=untar,type=history $SEND_FILE
+
+
+cd $WORKDIR/rundir
+
+
+if ($num < $NUM_TOT) then
+  echo "resubmitting... "
+  if ( "$SLURM_JOB_NAME" == "sh" ) then
+   cd $SCRIPT_AREA
+    ./$SCRIPT:t
+  else
+    cd $SCRIPT_AREA
+    #sbatch --export=ALL,DATE=${DATE} $SCRIPT:t
+    #sbatch -J ${DATE}.`basename $SLURM_JOB_NAME` --export=ALL,DATE=${DATE} $SCRIPT:t
+  echo "sleeping ... "
+    sleep 20
+  endif
+endif

--- a/RTS/GAEA_RTS/serialbox/C48_res.baroclinic.csh
+++ b/RTS/GAEA_RTS/serialbox/C48_res.baroclinic.csh
@@ -12,8 +12,7 @@ set echo
 set YourGroup  = "gfdl_f" #modify this to be your own group on f5
 set BASEDIR    = "/gpfs/f5/${YourGroup}/scratch/${USER}/"
 set INPUT_DATA = "/gpfs/f5/gfdl_w/proj-shared/fvGFS_INPUT_DATA"
-#set BUILD_AREA = "/ncrc/home1/${USER}/SHiELD_dev/SHiELD_build/"
-set BUILD_AREA = "/ncrc/home1/${USER}/work/20260129_translate_tests/PRs/SHiELD_build"
+set BUILD_AREA = "/ncrc/home1/${USER}/SHiELD_dev/SHiELD_build/"
 
 if ( ! $?COMPILER ) then
   set COMPILER = "intel"

--- a/RTS/GAEA_RTS/serialbox/run_tests.serialbox.sh
+++ b/RTS/GAEA_RTS/serialbox/run_tests.serialbox.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+#All tests in GAEA_RTS assume that you have cloned SHiELD_build at this location:
+#BUILD_AREA = "/ncrc/home1/${USER}/SHiELD_dev/SHiELD_build/"
+#The run directories will be at (as defined by the test scripts):
+#/gpfs/f5/${YourGroup}/scratch/${USER}/SHiELD_${RELEASE}
+#where YourGroup is defined in the runscripts and
+#RELEASE is defined in CHECKOUT_code when the code was compiled
+
+export COMPILER="intel"
+export MODE="64bit"
+export COMP="repro"
+ACCOUNT="gfdl_f"
+
+mkdir -p stdout
+
+sbatch C48_res.aquaplanet.csh --mail-user=${USER}@noaa.gov --mail-type=fail --account=${ACCOUNT}
+sbatch C48_res.baroclinic.csh --mail-user=${USER}@noaa.gov --mail-type=fail --account=${ACCOUNT}
+

--- a/site/environment.gnu.sh
+++ b/site/environment.gnu.sh
@@ -41,6 +41,7 @@ case $hostname in
        module load craype-hugepages4M
        module load cmake/3.27.9
        module load libyaml/0.2.5
+       module load boost
 
        # Add -DHAVE_GETTID to the FMS cppDefs
        export FMS_CPPDEFS=-DHAVE_GETTID

--- a/site/environment.intel.sh
+++ b/site/environment.intel.sh
@@ -45,6 +45,7 @@ case $hostname in
       module load craype-hugepages4M
       #module load cmake/3.27.9
       #module load libyaml/0.2.5
+      module load boost
 
       # Add -DHAVE_GETTID to the FMS cppDefs
       export FMS_CPPDEFS=-DHAVE_GETTID
@@ -83,6 +84,7 @@ case $hostname in
       module load craype-hugepages4M
       module load cmake/3.27.9
       module load libyaml/0.2.5
+      module load boost
 
       # Add -DHAVE_GETTID to the FMS cppDefs
       export FMS_CPPDEFS=-DHAVE_GETTID

--- a/site/gnu.mk
+++ b/site/gnu.mk
@@ -16,6 +16,7 @@ REPRO =
 VERBOSE =
 OPENMP =
 PIC =
+SERIAL =
 
 ##############################################
 # Need to use at least GNU Make version 3.81 #
@@ -40,9 +41,6 @@ else
   INCLUDE = -I$(NETCDF_ROOT)/include
   LIBS += -lnetcdff -lnetcdf -lhdf5_hl -lhdf5 -lz
 endif
-
-LIBSERIALBOX := -L$(SERIALBOX_ROOT)/lib -lSerialboxFortran -lSerialboxC -lSerialboxCore -lpthread -lstdc++ -lstdc++fs
-INCLUDE += -I$(SERIALBOX_ROOT)/include
 
 INCLUDE += $(shell pkg-config --cflags yaml-0.1)
 FPPFLAGS := -cpp -Wp,-w $(INCLUDE)
@@ -73,6 +71,18 @@ FFLAGS += -fPIC
 CFLAGS += -fPIC
 CPPFLAGS += -fPIC
 endif
+
+# For SerialBox Support (e.g., Serialization used for validation between Pace and
+# SHiELD), setting the SERIAL option to 'Y' with this Makefile template will
+# enable this.
+$(warning SERIAL = $(SERIAL))
+ifeq ($(SERIAL),Y)
+  INCLUDE += -I$(SERIALBOX_ROOT)/include
+  LIBS += -L$(SERIALBOX_ROOT)/lib -lSerialboxFortran -lSerialboxC -lSerialboxCore -lpthread -lstdc++ -lstdc++fs -Wl,-rpath,$(SERIALBOX_ROOT)/lib
+  CPPFLAGS += -DSERIALIZE
+endif
+#LIBSERIALBOX := -L$(SERIALBOX_ROOT)/lib -lSerialboxFortran -lSerialboxC -lSerialboxCore -lpthread -lstdc++ -lstdc++fs
+#INCLUDE += -I$(SERIALBOX_ROOT)/include
 
 FFLAGS_OPT = -O2 -fno-range-check
 FFLAGS_REPRO = -O2 -ggdb -fno-range-check
@@ -136,7 +146,8 @@ ifeq ($(NETCDF),3)
 endif
 
 LIBS += $(shell pkg-config --libs yaml-0.1)
-LDFLAGS += $(LIBS) -L$(NETCDF_ROOT)/lib -L$(HDF5_DIR)/lib $(LIBSERIALBOX)
+#LDFLAGS += $(LIBS) -L$(NETCDF_ROOT)/lib -L$(HDF5_DIR)/lib $(LIBSERIALBOX)
+LDFLAGS += $(LIBS) -L$(NETCDF_ROOT)/lib -L$(HDF5_DIR)/lib
 
 #---------------------------------------------------------------------------
 # you should never need to change any lines below.

--- a/site/gnu.mk
+++ b/site/gnu.mk
@@ -29,7 +29,7 @@ endif
 MAKEFLAGS += --jobs=8
 
 NETCDF_ROOT = $(NETCDF_DIR)
-MPI_ROOT    = $(MPICH_DIR)
+MPI_ROOT = $(MPICH_DIR)
 # start with blank LIB
 LIBS :=
 
@@ -40,6 +40,10 @@ else
   INCLUDE = -I$(NETCDF_ROOT)/include
   LIBS += -lnetcdff -lnetcdf -lhdf5_hl -lhdf5 -lz
 endif
+
+LIBSERIALBOX := -L$(SERIALBOX_ROOT)/lib -lSerialboxFortran -lSerialboxC -lSerialboxCore -lpthread -lstdc++ -lstdc++fs
+INCLUDE += -I$(SERIALBOX_ROOT)/include
+
 INCLUDE += $(shell pkg-config --cflags yaml-0.1)
 FPPFLAGS := -cpp -Wp,-w $(INCLUDE)
 CPPFLAGS := $(shell pkg-config --cflags yaml-0.1)
@@ -130,8 +134,9 @@ ifeq ($(NETCDF),3)
     CPPDEFS += -Duse_LARGEFILE
   endif
 endif
+
 LIBS += $(shell pkg-config --libs yaml-0.1)
-LDFLAGS += $(LIBS) -L$(NETCDF_ROOT)/lib -L$(HDF5_DIR)/lib
+LDFLAGS += $(LIBS) -L$(NETCDF_ROOT)/lib -L$(HDF5_DIR)/lib $(LIBSERIALBOX)
 
 #---------------------------------------------------------------------------
 # you should never need to change any lines below.

--- a/site/gnu.mk
+++ b/site/gnu.mk
@@ -33,6 +33,7 @@ NETCDF_ROOT = $(NETCDF_DIR)
 MPI_ROOT = $(MPICH_DIR)
 # start with blank LIB
 LIBS :=
+FFLAGS :=
 
 ifneq (`nc-config --libs`,)
   INCLUDE = `nf-config --fflags` `nc-config --cflags`
@@ -42,11 +43,21 @@ else
   LIBS += -lnetcdff -lnetcdf -lhdf5_hl -lhdf5 -lz
 endif
 
+# For SerialBox Support (e.g., Serialization used for validation between Pace and
+# SHiELD), setting the SERIAL option to 'Y' with this Makefile template will
+# enable this.
+$(warning SERIAL = $(SERIAL))
+ifeq ($(SERIAL),Y)
+  INCLUDE += -I$(SERIALBOX_ROOT)/include
+  LIBS += -L$(SERIALBOX_ROOT)/lib -lSerialboxFortran -lSerialboxC -lSerialboxCore -lpthread -lstdc++ -lstdc++fs -Wl,-rpath,$(SERIALBOX_ROOT)/lib
+  FFLAGS += -DSERIALIZE
+endif
+
 INCLUDE += $(shell pkg-config --cflags yaml-0.1)
 FPPFLAGS := -cpp -Wp,-w $(INCLUDE)
 CPPFLAGS := $(shell pkg-config --cflags yaml-0.1)
 
-FFLAGS := $(INCLUDE) -fcray-pointer -ffree-line-length-none -fno-range-check -fbacktrace -fallow-argument-mismatch
+FFLAGS += $(INCLUDE) -fcray-pointer -ffree-line-length-none -fno-range-check -fbacktrace -fallow-argument-mismatch
 
 ifeq ($(32BIT),Y)
 CPPDEFS += -DOVERLOAD_R4 -DOVERLOAD_R8
@@ -71,18 +82,6 @@ FFLAGS += -fPIC
 CFLAGS += -fPIC
 CPPFLAGS += -fPIC
 endif
-
-# For SerialBox Support (e.g., Serialization used for validation between Pace and
-# SHiELD), setting the SERIAL option to 'Y' with this Makefile template will
-# enable this.
-$(warning SERIAL = $(SERIAL))
-ifeq ($(SERIAL),Y)
-  INCLUDE += -I$(SERIALBOX_ROOT)/include
-  LIBS += -L$(SERIALBOX_ROOT)/lib -lSerialboxFortran -lSerialboxC -lSerialboxCore -lpthread -lstdc++ -lstdc++fs -Wl,-rpath,$(SERIALBOX_ROOT)/lib
-  CPPFLAGS += -DSERIALIZE
-endif
-#LIBSERIALBOX := -L$(SERIALBOX_ROOT)/lib -lSerialboxFortran -lSerialboxC -lSerialboxCore -lpthread -lstdc++ -lstdc++fs
-#INCLUDE += -I$(SERIALBOX_ROOT)/include
 
 FFLAGS_OPT = -O2 -fno-range-check
 FFLAGS_REPRO = -O2 -ggdb -fno-range-check
@@ -146,7 +145,6 @@ ifeq ($(NETCDF),3)
 endif
 
 LIBS += $(shell pkg-config --libs yaml-0.1)
-#LDFLAGS += $(LIBS) -L$(NETCDF_ROOT)/lib -L$(HDF5_DIR)/lib $(LIBSERIALBOX)
 LDFLAGS += $(LIBS) -L$(NETCDF_ROOT)/lib -L$(HDF5_DIR)/lib
 
 #---------------------------------------------------------------------------

--- a/site/intel.mk
+++ b/site/intel.mk
@@ -33,6 +33,7 @@ NETCDF_ROOT = $(NETCDF_DIR)
 MPI_ROOT    = $(MPICH_DIR)
 # start with blank LIB
 LIBS :=
+FFLAGS :=
 
 ifneq (`nc-config --libs`,)
   INCLUDE = `nf-config --fflags` `nc-config --cflags`
@@ -42,11 +43,21 @@ else
   LIBS += -lnetcdff -lnetcdf -lhdf5_hl -lhdf5 -lz
 endif
 
+# For SerialBox Support (e.g., Serialization used for validation between Pace and
+# SHiELD), setting the SERIAL option to 'Y' with this Makefile template will
+# enable this.
+$(warning SERIAL = $(SERIAL))
+ifeq ($(SERIAL),Y)
+  INCLUDE += -I$(SERIALBOX_ROOT)/include
+  LIBS += -L$(SERIALBOX_ROOT)/lib -lSerialboxFortran -lSerialboxC -lSerialboxCore -lpthread -lstdc++ -lstdc++fs
+  FFLAGS += -DSERIALIZE
+endif
+
 INCLUDE += $(shell pkg-config --cflags yaml-0.1)
 FPPFLAGS := -fpp -Wp,-w $(INCLUDE)
 CPPFLAGS := $(shell pkg-config --cflags yaml-0.1)
 
-FFLAGS := $(INCLUDE) -fno-alias -auto -safe-cray-ptr -ftz -assume byterecl -nowarn -sox -align array64byte -traceback
+FFLAGS += $(INCLUDE) -fno-alias -auto -safe-cray-ptr -ftz -assume byterecl -nowarn -sox -align array64byte -traceback
 
 ifeq ($(32BIT),Y)
 FFLAGS += -DOVERLOAD_R4 -DOVERLOAD_R8 -i4 -real-size 32
@@ -71,16 +82,6 @@ CFLAGS += -fPIC
 CPPFLAGS += -fPIC
 endif
 
-# For SerialBox Support (e.g., Serialization used for validation between Pace and
-# SHiELD), setting the SERIAL option to 'Y' with this Makefile template will
-# enable this.
-$(warning SERIAL = $(SERIAL))
-ifeq ($(SERIAL),Y)
-  INCLUDE += -I$(SERIALBOX_ROOT)/include
-  LIBS += -L$(SERIALBOX_ROOT)/lib -lSerialboxFortran -lSerialboxC -lSerialboxCore -lpthread -lstdc++ -lstdc++fs
-  CPPFLAGS += -DSERIALIZE
-endif
-
 FFLAGS_OPT = -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3
 FFLAGS_REPRO = -O2 -debug minimal -fp-model source -qoverride-limits #-fpe0 #causes problems??
 FFLAGS_DEBUG = -g -O0 -debug -check -check noarg_temp_created -check nopointer -warn -warn noerrors -fp-stack-check -fstack-protector-all -fpe0 -ftrapuv
@@ -89,7 +90,7 @@ TRANSCENDENTALS := -fast-transcendentals
 FFLAGS_OPENMP = -qopenmp
 FFLAGS_VERBOSE = -v -V -what
 
-CFLAGS := -D__IFC -sox -msse2 -fp-model source
+CFLAGS := -D__IFC -sox -msse2
 ifeq ($(AVX2),Y)
 #CFLAGS += -xHOST -xCORE-AVX2 -qno-opt-dynamic-align
 endif

--- a/site/intel.mk
+++ b/site/intel.mk
@@ -42,16 +42,6 @@ else
   LIBS += -lnetcdff -lnetcdf -lhdf5_hl -lhdf5 -lz
 endif
 
-# For SerialBox Support (e.g., Serialization used for validation between Pace and
-# SHiELD), setting the SERIAL option to 'Y' with this Makefile template will
-# enable this.
-$(warning SERIAL = $(SERIAL))
-ifeq ($(SERIAL),Y)
-  INCLUDE += -I$(SERIALBOX_ROOT)/include
-  LIBS += -L$(SERIALBOX_ROOT)/lib -lSerialboxFortran -lSerialboxC -lSerialboxCore -lpthread -lstdc++ -lstdc++fs
-  CPPFLAGS += -DSERIALIZE
-endif
-
 INCLUDE += $(shell pkg-config --cflags yaml-0.1)
 FPPFLAGS := -fpp -Wp,-w $(INCLUDE)
 CPPFLAGS := $(shell pkg-config --cflags yaml-0.1)
@@ -79,6 +69,16 @@ ifeq ($(PIC),Y)
 FFLAGS += -fPIC
 CFLAGS += -fPIC
 CPPFLAGS += -fPIC
+endif
+
+# For SerialBox Support (e.g., Serialization used for validation between Pace and
+# SHiELD), setting the SERIAL option to 'Y' with this Makefile template will
+# enable this.
+$(warning SERIAL = $(SERIAL))
+ifeq ($(SERIAL),Y)
+  INCLUDE += -I$(SERIALBOX_ROOT)/include
+  LIBS += -L$(SERIALBOX_ROOT)/lib -lSerialboxFortran -lSerialboxC -lSerialboxCore -lpthread -lstdc++ -lstdc++fs
+  CPPFLAGS += -DSERIALIZE
 endif
 
 FFLAGS_OPT = -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3

--- a/site/intel.mk
+++ b/site/intel.mk
@@ -16,6 +16,7 @@ REPRO =
 VERBOSE =
 OPENMP =
 PIC =
+SERIAL =
 
 ##############################################
 # Need to use at least GNU Make version 3.81 #
@@ -41,8 +42,15 @@ else
   LIBS += -lnetcdff -lnetcdf -lhdf5_hl -lhdf5 -lz
 endif
 
-LIBS += -L$(SERIALBOX_ROOT)/lib -lSerialboxFortran -lSerialboxC -lSerialboxCore -lpthread -lstdc++ -lstdc++fs
-INCLUDE += -I$(SERIALBOX_ROOT)/include
+# For SerialBox Support (e.g., Serialization used for validation between Pace and
+# SHiELD), setting the SERIAL option to 'Y' with this Makefile template will
+# enable this.
+$(warning SERIAL = $(SERIAL))
+ifeq ($(SERIAL),Y)
+  INCLUDE += -I$(SERIALBOX_ROOT)/include
+  LIBS += -L$(SERIALBOX_ROOT)/lib -lSerialboxFortran -lSerialboxC -lSerialboxCore -lpthread -lstdc++ -lstdc++fs
+  CPPFLAGS += -DSERIALIZE
+endif
 
 INCLUDE += $(shell pkg-config --cflags yaml-0.1)
 FPPFLAGS := -fpp -Wp,-w $(INCLUDE)

--- a/site/intel.mk
+++ b/site/intel.mk
@@ -40,6 +40,10 @@ else
   INCLUDE = -I$(NETCDF_ROOT)/include
   LIBS += -lnetcdff -lnetcdf -lhdf5_hl -lhdf5 -lz
 endif
+
+LIBS += -L$(SERIALBOX_ROOT)/lib -lSerialboxFortran -lSerialboxC -lSerialboxCore -lpthread -lstdc++ -lstdc++fs
+INCLUDE += -I$(SERIALBOX_ROOT)/include
+
 INCLUDE += $(shell pkg-config --cflags yaml-0.1)
 FPPFLAGS := -fpp -Wp,-w $(INCLUDE)
 CPPFLAGS := $(shell pkg-config --cflags yaml-0.1)
@@ -77,7 +81,7 @@ TRANSCENDENTALS := -fast-transcendentals
 FFLAGS_OPENMP = -qopenmp
 FFLAGS_VERBOSE = -v -V -what
 
-CFLAGS := -D__IFC -sox -msse2
+CFLAGS := -D__IFC -sox -msse2 -fp-model source
 ifeq ($(AVX2),Y)
 #CFLAGS += -xHOST -xCORE-AVX2 -qno-opt-dynamic-align
 endif


### PR DESCRIPTION
**Description**

This PR adds SerialBox capabilities into SHiELD_build in order to facilitate validation between Pace and SHiELD. This work builds off of @oelbert 's [serialbox_build branch](https://github.com/oelbert/SHiELD_build/tree/serialbox_build).

The COMPILE script will have a new option to toggle SerialBox usage. For example:

`./COMPILE cleanall shield nh repro 64bit intel serial`
`./COMPILE cleanall shield nh repro 64bit intel noserial`

The default behavior will be `noserial`, so that existing functionality will remain the same for non-SerialBox users.

The main code changes include the following:
- The `COMPILE` script has been modified to build SerialBox and create a separate source tree `SHiELD_SRC_SER` that is parallel to `SHiELD_SRC`. This alternative source tree will be where SerialBox pre-preprocessor directives will be converted to Fortran prior to building the executable.
- A new BUILDserialbox script will be called within COMPILE to clone and install SerialBox.
- Example RTS scripts have been added for Pace validation (Baroclinic, Aquaplanet) with settings that are Pace-friendly.
- Related modifications were made to `mk_make`, `intel.mk`, and `gnu.mk` for SerialBox compile dependencies.
- The site environment scripts have been modified to include Boost.
- The `serialbox` directories have been added to .gitignore.

**How Has This Been Tested?**

On Gaea (C5), it's been tested using both gnu and intel options using a modified SHiELD_SRC:

`git clone -b $20260219_serialbox git@github.com:jjuyeonkim/GFDL_atmos_cubed_sphere.git`
`git clone -b $20260305_serialbox git@github.com:jjuyeonkim/atmos_drivers.git`
`git clone -b 20260219_serialbox git@github.com:jjuyeonkim/FMSCoupler.git`

The following options were tested:
1. Works as expected:`./COMPILE cleanall shield nh repro 64bit intel serial`
    RTS/GAEA_RTS/serialbox/run_tests.serialbox.sh generates SerialBox data

2. Works as expected:`./COMPILE cleanall shield nh repro 64bit intel noserial`
   RTS/GAEA_RTS/serialbox/run_tests.serialbox.sh does NOT generate SerialBox data

3. Builds without error but gnu test isn't available: `./COMPILE cleanall shield nh repro 64bit gnu serial`
4. Builds without error but gnu test isn't available: `./COMPILE cleanall shield nh repro 64bit gnu noserial`

5. Builds and generates sanity data: `./COMPILE cleanall solo nh repro 64bit gnu serial`
Tested with `C96.solo.BCmoist` script as sanity check and generates SerialBox Data                                                                                                                                                     
Needs: `export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${BUILDDIR}/Build/serialbox/${COMPILER}/serialbox2/build/install/lib`  

6. Builds and generates sanity data: `./COMPILE cleanall solo nh repro 64bit intel serial`
Tested with `C96.solo.BCmoist script` as sanity check and generates SerialBox Data                                                                                                                                                     
Needs: `export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${BUILDDIR}/Build/serialbox/${COMPILER}/serialbox2/build/install/lib`  

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules